### PR TITLE
chore: turn on merge queue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
       - main
   schedule:
     - cron: '05 10 * * *'  # 10:05am UTC everyday
+  merge_group:  
   push:
     branches:
       - main


### PR DESCRIPTION
Added rulesets in the github settings so that PRs must pass green before merging.