### PR TITLE
[chore] hardcode IMAGE_NAME in the github workflow for now

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 env:
-  IMAGE_NAME: "${{ github.event.repository.name }}"  # the name of the image produced by this build, matches repo names
+  IMAGE_NAME: "achillobator"  # the name of the image produced by this build, matches repo names
   IMAGE_DESC: "CentOS Stream-based images"
   IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}"
   DEFAULT_TAG: "latest"


### PR DESCRIPTION
using ${{ github.event.repository.name }} in the top level env on the
build workflow was resulting in IMAGE_NAME being unset, which was defaulting
back to the default set in the Justfile.

This resulted in confusion for users forking the repo and/or workflows