### PR TITLE
Remove disk nuking kickstart configuration

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -156,7 +156,7 @@ _build-bib $target_image $tag $type $config: (_rootful_load_image target_image t
       --pull=newer \
       --net=host \
       --security-opt label=type:unconfined_t \
-      -v $(pwd)/${config} \
+      -v $(pwd)/${config}:/config.toml:ro \
       -v $(pwd)/output:/output \
       -v /var/lib/containers/storage:/var/lib/containers/storage \
       "${bib_image}" \

--- a/image-builder-iso.config.toml
+++ b/image-builder-iso.config.toml
@@ -1,6 +1,5 @@
-[customizations.installer.kickstart]
-contents = """
-"""
+[customizations.installer]
+unattended = false 
 
 [customizations.installer.modules]
 enable = [
@@ -13,5 +12,14 @@ enable = [
   "org.fedoraproject.Anaconda.Modules.Storage",
   "org.fedoraproject.Anaconda.Modules.Subscription",
   "org.fedoraproject.Anaconda.Modules.Timezone",
-  "org.fedoraproject.Anaconda.Modules.Users"
+  "org.fedoraproject.Anaconda.Modules.Users" 
 ]
+
+[org.fedoraproject.Anaconda.Modules.Storage]
+automatic = false
+
+[customizations.installer.kickstart]
+contents = """
+firstboot --enable
+reboot
+"""

--- a/image-builder-iso.config.toml
+++ b/image-builder-iso.config.toml
@@ -1,25 +1,17 @@
-[customizations.installer]
-unattended = false 
+[customizations.installer.kickstart]
+contents = """
+# NOOP - do not remove this else the installer will automatically partition the disk
+"""
 
 [customizations.installer.modules]
 enable = [
-  "org.fedoraproject.Anaconda.Modules.Localization",
+  "org.fedoraproject.Anaconda.Modules.Storage"
+]
+disable = [
   "org.fedoraproject.Anaconda.Modules.Network",
-  "org.fedoraproject.Anaconda.Modules.Payloads",
-  "org.fedoraproject.Anaconda.Modules.Runtime",
   "org.fedoraproject.Anaconda.Modules.Security",
   "org.fedoraproject.Anaconda.Modules.Services",
-  "org.fedoraproject.Anaconda.Modules.Storage",
+  "org.fedoraproject.Anaconda.Modules.Users",
   "org.fedoraproject.Anaconda.Modules.Subscription",
-  "org.fedoraproject.Anaconda.Modules.Timezone",
-  "org.fedoraproject.Anaconda.Modules.Users" 
+  "org.fedoraproject.Anaconda.Modules.Timezone" 
 ]
-
-[org.fedoraproject.Anaconda.Modules.Storage]
-automatic = false
-
-[customizations.installer.kickstart]
-contents = """
-firstboot --enable
-reboot
-"""


### PR DESCRIPTION
Remove the disk nuking kickstart configuration and adjust the installer settings to disable unattended installation. Add firstboot and reboot commands to the kickstart contents.


Fix the config.toml to be mounted wit the correct name. THings were deafulting to the default autoinstall