### PR TITLE
remove jetbrains font setting

### DIFF
--- a/system_files/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+++ b/system_files/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
@@ -17,7 +17,6 @@ clock-show-weekday=true
 font-antialiasing="rgba"
 font-name="Inter 12"
 document-font-name="Inter 12"
-monospace-font-name="JetBrains Mono 18"
 accent-color="slate"
 
 [org.gnome.desktop.sound]


### PR DESCRIPTION
the font isn't in the image so it causes a broken terminal experience out of the bot