### PR TITLE
fix: remove console-login-helper profile.d removal

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -52,10 +52,6 @@ fi
 # Fix issues caused by ID no longer being rhel??? (FIXME: check if this is necessary)
 sed -i "s/^EFIDIR=.*/EFIDIR=\"rhel\"/" /usr/sbin/grub2-switch-to-blscfg
 
-# This thing adds "[systemd] Failed Units: (whatever)" to the bashrc startup. We arent using this as a server, we dont need this.
-rm "/usr/share/console-login-helper-messages/profile.sh"
-rm "/etc/profile.d/console-login-helper-messages-profile.sh"
-
 # Additions
 dnf -y install \
     distrobox \


### PR DESCRIPTION
Managed to find what makes this show up. Its a few packages on main, fixed on: https://github.com/centos-workstation/main/commit/2955dc3166e3dd053c7fa4963e04f9f3159fce3e.
