### PR TITLE
chore: remove `brew install gcc` from build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -107,7 +107,6 @@ touch /.dockerenv
 curl --retry 3 -Lo /tmp/brew-install https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh
 chmod +x /tmp/brew-install
 /tmp/brew-install
-/home/linuxbrew/.linuxbrew/bin/brew install gcc
 tar --zstd -cvf /usr/share/homebrew.tar.zst /home/linuxbrew
 rm -f /.dockerenv
 


### PR DESCRIPTION
Apparently adding `brew install gcc` adds portable ruby and all gcc dependencies to the Homebrew installation (thus makes the image a ton bigger). Just having GCC on the host system should satisfy `brew doctor`'s checking.
