### PR TITLE
chore: clean brew on image build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -109,6 +109,8 @@ chmod +x /tmp/brew-install
 /tmp/brew-install
 tar --zstd -cvf /usr/share/homebrew.tar.zst /home/linuxbrew
 rm -f /.dockerenv
+# Clean up brew artifacts on the image.
+rm -rf /home/linuxbrew /root/.cache
 
 # Services
 systemctl enable dconf-update.service


### PR DESCRIPTION
This should not change any behaviour for anything brew related, it just removes the /home/linuxbrew and /root/.cache folders from the image. ostree already strips out those folders when we deploy the images to end users, so there is really no downside in this. It should free up a little bit of space from the image size.

My local builds were `4.87 GB` and now they are `4.84 GB`
