### PR TITLE
chore: remove rpm-ostree from end-user image

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -62,7 +62,8 @@ dnf -y install \
 
 # Removals
 dnf -y remove \
-    subscription-manager
+    subscription-manager \
+    rpm-ostree
 
 # Repos 
 dnf -y --enablerepo epel-testing install \


### PR DESCRIPTION
We are working on this being as Bootc centric as possible, having rpm-ostree is going to make people think the rpm-ostree centric stuff like layering still works on this (which is doesnt. and if it does, will not be supported.)
