### PR TITLE
fix: cron rules for changelog + fix path to script

### DIFF
--- a/.github/workflows/generate-changelog-release.yml
+++ b/.github/workflows/generate-changelog-release.yml
@@ -1,17 +1,21 @@
 on:
+  schedule:
+    - cron: '05 11 * * *' # 11:05am UTC everyday
   workflow_call:
     inputs:
       stream_name:
         description: "Release Tag (e.g. stream10, latest)"
         type: string
-        required: true
+        default: "latest"
+        required: false
   workflow_dispatch:
     inputs:
       handwritten:
         description: "Small Changelog about changes in this build"
       stream_name:
         description: "Release Tag (e.g. gts, stable)"
-        required: true
+        required: false
+        default: '["latest"]'
         type: choice
         options:
           - '["stream10"]'
@@ -40,7 +44,7 @@ jobs:
         id: generate-release-text
         shell: bash
         run: |
-          python3 changelogs.py --workdir . "${{ matrix.version }}" ./output.env ./changelog.md --handwritten "${{ inputs.handwritten }}" 
+          python3 .github/changelogs.py --workdir . "${{ matrix.version }}" ./output.env ./changelog.md --handwritten "${{ inputs.handwritten }}" 
           source ./output.env
           echo "title=${TITLE}" >> $GITHUB_OUTPUT
           echo "tag=${TAG}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Should fix the broken path for the action :p and adds default values for the inputs so that we dont need to manually release
