### PR TITLE
fix: add font override so that ptyxis doesnt have broken font by default

### DIFF
--- a/system_files/usr/share/glib-2.0/schemas/zz1-achillobator-modifications.gschema.override
+++ b/system_files/usr/share/glib-2.0/schemas/zz1-achillobator-modifications.gschema.override
@@ -1,0 +1,2 @@
+[org.gnome.desktop.interface]
+monospace-font-name="Red Hat Mono Medium 16"


### PR DESCRIPTION
This should get fixed whenever Jetbrains fonts are on EPEL, its just a workaround that sets the RedHat mono font as a default for now. I am not super sure this works, I usually just set it to another font anyways.
