### PR TITLE
feat: remove gnome-extensions app

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -59,7 +59,6 @@ QUALIFIED_KERNEL="$(rpm -qa | grep -P 'kernel-(|'"$KERNEL_SUFFIX"'-)(\d+\.\d+\.\
 # Additions
 dnf -y install \
     distrobox \
-    gnome-extensions-app \
     gnome-shell-extension-appindicator \
     gnome-shell-extension-dash-to-dock \
     gnome-tweaks \


### PR DESCRIPTION
People should be using the better extension-manager and this will allow there to be only one extensions app. User experience will suffer if they accidentally try to use the regular gnome extensions app. So best to have 0 or the 1 good one. instead of 1 bad one or 2 extensions apps showing up in search every time and you having to avoid the bad one