### PR TITLE
fix: mask bootc update timer and service as they are still getting ran

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -127,4 +127,4 @@ systemctl enable brew-setup.service
 systemctl disable mcelog.service
 systemctl enable tailscaled.service
 systemctl enable uupd.timer
-systemctl disable bootc-fetch-apply-updates.timer bootc-fetch-apply-updates.service
+systemctl mask bootc-fetch-apply-updates.timer bootc-fetch-apply-updates.service


### PR DESCRIPTION
For some reason disabiling those doesnt seem to have any effect on runtime? I still get the timer and my PC suddenly shuts down.
