### PR TITLE
fix: remove systemd-container to make polkit work

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -58,8 +58,10 @@ dnf -y install \
     gnome-shell-extension-appindicator \
     gnome-shell-extension-dash-to-dock \
     gnome-tweaks \
-    tuned-ppd \
-    systemd-container # uupd depends on machinectl
+    tuned-ppd
+
+# FIXME: temporarily removed because it breaks pkexec currently (systemd 257->256 downgrade).
+# dnf install -y systemd-container
 
 # Removals
 dnf -y remove \


### PR DESCRIPTION
Polkit is currently breaking due to systemd-container and the package downgrade it has. This will break `uupd`'s ability to upgrade user packages, but its better breaking uupd than polkit in this case.

Fixes: #103

This might not be necessary soon if https://github.com/hhd-dev/rechunk/pull/8 gets merged. I'd merge this anyways because having polkit broken is a pretty big issue