### PR TITLE
chore: remove unnecessary workaround for grub2-switch-to-blsconfig

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -49,9 +49,6 @@ if [[ -n "${SHA_HEAD_SHORT:-}" ]]; then
   echo "BUILD_ID=\"$SHA_HEAD_SHORT\"" >> /usr/lib/os-release
 fi
 
-# Fix issues caused by ID no longer being rhel??? (FIXME: check if this is necessary)
-sed -i "s/^EFIDIR=.*/EFIDIR=\"rhel\"/" /usr/sbin/grub2-switch-to-blscfg
-
 # Additions
 dnf -y install \
     distrobox \


### PR DESCRIPTION
This workaround on `build.sh` is entirely unnecessary because grub-switch-to-blsconfig checks for "redhat" on the `/usr/lib/ostree-boot/boot/efi/(redhat_here)` directory. Removing this makes it evaluate to `centos`, which most likely will be the default for bootupd whenever it is enabled. If it gets enabled and this is wrong, we can change it again. For now, absolutely no need for this workaround

![image](https://github.com/user-attachments/assets/12cdf5e5-e0b2-434f-ac3f-01534c4acf0c)
