### PR TITLE
chore: remove systemd-container from the build for now

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -55,8 +55,11 @@ dnf -y install \
     gnome-shell-extension-appindicator \
     gnome-shell-extension-dash-to-dock \
     gnome-tweaks \
-    tuned-ppd \
-    systemd-container # uupd depends on machinectl
+    tuned-ppd
+
+# FIXME: Re-add systemd-container when repos are synced up again.
+# This currently downgrades systemd to 256 and breaks polkit because of it.  
+# systemd-container # uupd depends on machinectl
 
 # Removals
 dnf -y remove \


### PR DESCRIPTION
This breaks the user experience very much and we gotta remove this just for now. It should be fine when the repos resync again
