### PR TITLE
chore(ci): use docker metadata action for image tags

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -54,60 +54,25 @@ jobs:
         with:
           remove-codeql: true
 
-      - name: Generate tags
-        id: generate-tags
-        shell: bash
-        run: |
-          # Generate a timestamp for creating an image version history
-          TIMESTAMP="$(date +%Y%m%d)"
-          COMMIT_TAGS=()
-          BUILD_TAGS=()
-
-          # Have tags for tracking builds during pull request
-          SHA_SHORT="${GITHUB_SHA::7}"
-          COMMIT_TAGS+=("pr-${{ github.event.number }}")
-          COMMIT_TAGS+=("${SHA_SHORT}")
-
-          # Append matching timestamp tags to keep a version history
-          for TAG in "${BUILD_TAGS[@]}"; do
-              BUILD_TAGS+=("${TAG}-${TIMESTAMP}")
-          done
-
-          BUILD_TAGS+=("${TIMESTAMP}")
-          BUILD_TAGS+=("${DEFAULT_TAG}")
-          BUILD_TAGS+=("${CENTOS_VERSION}")
-          BUILD_TAGS+=("${CENTOS_VERSION}.${TIMESTAMP}")
-          BUILD_TAGS+=("latest.${TIMESTAMP}")
-
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-              echo "Generated the following commit tags: "
-              for TAG in "${COMMIT_TAGS[@]}"; do
-                  echo "${TAG}"
-              done
-
-              alias_tags=("${COMMIT_TAGS[@]}")
-          else
-              alias_tags=("${BUILD_TAGS[@]}")
-          fi
-
-          echo "Generated the following build tags: "
-          for TAG in "${BUILD_TAGS[@]}"; do
-              echo "${TAG}"
-          done
-
-          echo "alias_tags=${alias_tags[*]}" >> $GITHUB_OUTPUT
-
-      # Build metadata
       - name: Image Metadata
         uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 # v5
-        id: meta
+        id: metadata
         with:
-          images: |
-            ${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value={{date 'YYYYMMDD'}},enable={{is_default_branch}}
+            type=raw,value=${{ env.CENTOS_VERSION }},enable={{is_default_branch}}
+            type=raw,value=${{ env.CENTOS_VERSION }}.{{date 'YYYYMMDD'}},enable={{is_default_branch}}
+            type=sha,enable=${{ github.event_name == 'pull_request' }}
+            type=ref,event=pr
           labels: |
-            io.artifacthub.package.readme-url=${{ env.README_URL }}
             org.opencontainers.image.description=${{ env.IMAGE_DESC }}
             org.opencontainers.image.title=${{ env.IMAGE_NAME }}
+            io.artifacthub.package.readme-url=${{ env.README_URL }}
+            io.artifacthub.package.logo-url=${{ env.LOGO_URL }}
+          sep-tags: " "
+          sep-labels: " "
+          sep-annotations: " "
 
       - name: Build Image
         id: build-image
@@ -126,17 +91,12 @@ jobs:
           prev-ref: "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}"
           skip_compression: true
           version: ${{ env.CENTOS_VERSION }}
-          labels: |
-            org.opencontainers.image.title=${{ env.IMAGE_NAME }}
-            org.opencontainers.image.description=${{ env.IMAGE_DESC }}
-            io.artifacthub.package.readme-url=${{ env.README_URL }}
-            io.artifacthub.package.logo-url=${{ env.LOGO_URL }}
 
       - name: Load in podman and tag
         run: |
           IMAGE=$(podman pull ${{ steps.rechunk.outputs.ref }})
-          sudo rm -rf ${{ steps.rechunk.outputs.output }}
-          for tag in ${{ steps.generate-tags.outputs.alias_tags }}; do
+          sudo rm -rf ${{ steps.rechunk.outputs.output }} || echo "Somehow failed this"
+          for tag in ${{ steps.metadata.outputs.tags }}; do
             podman tag $IMAGE ${{ env.IMAGE_NAME }}:$tag
           done
 
@@ -163,9 +123,7 @@ jobs:
         with:
           registry: ${{ steps.registry_case.outputs.lowercase }}
           image: ${{ env.IMAGE_NAME }}
-          tags: ${{ steps.generate-tags.outputs.alias_tags }}
-          extra-args: |
-            --disable-content-trust
+          tags: ${{ steps.metadata.outputs.tags }}
 
       # This section is optional and only needs to be enabled in you plan on distributing
       # your project to others to consume. You will need to create a public and private key
@@ -180,7 +138,9 @@ jobs:
         if: github.event_name != 'pull_request'
         run: |
           IMAGE_FULL="${{ steps.registry_case.outputs.lowercase }}/${IMAGE_NAME}"
-          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${IMAGE_FULL}@${TAGS}
+          for tag in ${{ steps.metadata.outputs.tags }}; do
+            cosign sign -y --key env://COSIGN_PRIVATE_KEY $IMAGE_FULL:$tag
+          done
         env:
           TAGS: ${{ steps.push.outputs.digest }}
           COSIGN_EXPERIMENTAL: false


### PR DESCRIPTION
This works!!! This is an adaptation of [@detiber's PR](https://github.com/centos-workstation/main/pull/16) but on Achillobator.

I managed to build it on a custom image with my creds and stuff at https://github.com/tulilirockz/achillobator-testing/actions/runs/12592418045! It works just fine and generates the tags properly. We can later add labels support for the `just build` and use this action for the labeling too! (thus we can fix up the artifacthub metadata issue!!)

This should be mergeable as-is.