### PR TITLE
fix: metadata with rechunk + remove workarounds we dont need

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -62,9 +62,10 @@ jobs:
         with:
           tags: |
             type=raw,value=latest
-            type=raw,value={{date 'YYYYMMDD'}},enable={{is_default_branch}}
-            type=raw,value=${{ env.CENTOS_VERSION }},enable={{is_default_branch}}
-            type=raw,value=${{ env.CENTOS_VERSION }}.{{date 'YYYYMMDD'}},enable={{is_default_branch}}
+            type=raw,value=latest.{{date 'YYYYMMDD'}}
+            type=raw,value={{date 'YYYYMMDD'}}
+            type=raw,value=${{ env.CENTOS_VERSION }}
+            type=raw,value=${{ env.CENTOS_VERSION }}.{{date 'YYYYMMDD'}}
             type=sha,enable=${{ github.event_name == 'pull_request' }}
             type=ref,event=pr
           labels: |
@@ -84,8 +85,8 @@ jobs:
             io.artifacthub.package.logo-url=https://avatars.githubusercontent.com/u/120078124?s=200&v=4
             io.artifacthub.package.maintainers=[{"name":"tulilirockz","email":"tulilirockz@outlook.com"},{"name":"castrojo", "email": "jorge.castro@gmail.com"}]
             io.artifacthub.package.prerelease=true
+            containers.bootc=1
           sep-tags: " "
-          sep-labels: " "
           sep-annotations: " "
 
       - name: Build Image
@@ -93,7 +94,7 @@ jobs:
         shell: bash
         run: |
           just=$(which just)
-          sudo $just build "${IMAGE_NAME}" "${DEFAULT_TAG}" "${{ steps.metadata.outputs.labels }}"
+          sudo $just build "${IMAGE_NAME}" "${DEFAULT_TAG}"
 
       # Reprocess raw-img using rechunker which will delete it
       - name: Run Rechunker
@@ -105,25 +106,19 @@ jobs:
           prev-ref: "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}"
           skip_compression: true
           version: ${{ env.CENTOS_VERSION }}
+          labels: ${{ steps.metadata.outputs.labels }} # Rechunk strips out all the labels during build, this needs to be reapplied here with newline separator
 
       - name: Load in podman and tag
         run: |
           IMAGE=$(podman pull ${{ steps.rechunk.outputs.ref }})
-          sudo rm -rf ${{ steps.rechunk.outputs.output }} || echo "Somehow failed this"
+          sudo rm -rf ${{ steps.rechunk.outputs.output }}
           for tag in ${{ steps.metadata.outputs.tags }}; do
             podman tag $IMAGE ${{ env.IMAGE_NAME }}:$tag
           done
 
-      # Workaround bug where capital letters in your GitHub username make it impossible to push to GHCR.
-      # https://github.com/macbre/push-to-ghcr/issues/12
-      - name: Lowercase Registry
-        id: registry_case
-        uses: ASzc/change-string-case-action@d0603cd0a7dd490be678164909f65c7737470a7f # v6
-        with:
-          string: ${{ env.IMAGE_REGISTRY }}
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
+        if: github.event_name != 'pull_request'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -135,7 +130,7 @@ jobs:
         if: github.event_name != 'pull_request'
         id: push
         with:
-          registry: ${{ steps.registry_case.outputs.lowercase }}
+          registry: ${{ env.IMAGE_REGISTRY }}
           image: ${{ env.IMAGE_NAME }}
           tags: ${{ steps.metadata.outputs.tags }}
 

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -69,7 +69,7 @@ jobs:
             type=sha,enable=${{ github.event_name == 'pull_request' }}
             type=ref,event=pr
           labels: |
-            io.artifacthub.package.readme-url=https://raw.githubusercontent.com/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}/${{ env.IMAGE_NAME }}/README.md
+            io.artifacthub.package.readme-url=https://raw.githubusercontent.com/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}/refs/heads/main/README.md
             org.opencontainers.image.created=${{ steps.date.outputs.date }}
             org.opencontainers.image.description=${{ env.IMAGE_DESC }}
             org.opencontainers.image.documentation=https://docs.projectbluefin.io

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -127,7 +127,7 @@ jobs:
       # Push the image to GHCR (Image Registry)
       - name: Push To GHCR
         uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         id: push
         with:
           registry: ${{ env.IMAGE_REGISTRY }}
@@ -141,10 +141,10 @@ jobs:
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
 
       - name: Sign container image
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         run: |
           IMAGE_FULL="${{ steps.registry_case.outputs.lowercase }}/${IMAGE_NAME}"
           for tag in ${{ steps.metadata.outputs.tags }}; do

--- a/Justfile
+++ b/Justfile
@@ -74,7 +74,7 @@ sudoif command *args:
     }
     sudoif {{ command }} {{ args }}
 
-build $target_image=image_name $tag=default_tag *$labels="":
+build $target_image=image_name $tag=default_tag:
     #!/usr/bin/env bash
 
     # Get Version
@@ -87,14 +87,9 @@ build $target_image=image_name $tag=default_tag *$labels="":
     if [[ -z "$(git status -s)" ]]; then
         BUILD_ARGS+=("--build-arg" "SHA_HEAD_SHORT=$(git rev-parse --short HEAD)")
     fi
-    LABELS=()
-    for label in $labels ; do
-        LABELS+=("--label" $label)
-    done
 
     podman build \
         "${BUILD_ARGS[@]}" \
-        "${LABELS[@]}" \
         --pull=newer \
         --tag "${image_name}:${tag}" \
         .


### PR DESCRIPTION
Rechunk strips out all the labels from the images, this should fix it. I also cleaned up the action a bit as:
- Apparently https://github.com/macbre/push-to-ghcr/issues/12 already got fixed upstream (https://github.com/macbre/push-to-ghcr/pull/24)
- Some steps are useless for pull requests
- Had to remove `is_default_branch` from the tags because else it would break image tagging on merge_queue
- And added a latest.DATE tag! 
