### PR TITLE
chore: add podman desktop as a default flatpak

### DIFF
--- a/system_files/etc/ublue-os/system-flatpaks.list
+++ b/system_files/etc/ublue-os/system-flatpaks.list
@@ -29,3 +29,4 @@ org.mozilla.Thunderbird
 page.tesk.Refine
 runtime/org.gtk.Gtk3theme.adw-gtk3
 runtime/org.gtk.Gtk3theme.adw-gtk3-dark
+io.podman_desktop.PodmanDesktop


### PR DESCRIPTION
We are going the DX way, might as well add this.

Fixes: #134 