### PR TITLE
fix: remove install errors on build that did not get caught

### DIFF
--- a/build_scripts/20-packages.sh
+++ b/build_scripts/20-packages.sh
@@ -42,10 +42,10 @@ dnf -y --enablerepo copr:copr.fedorainfracloud.org:ublue-os:staging install \
 	ublue-bling \
 	bluefin-*
 
-dnf -y --enablerepo "copr:copr.fedorainfracloud.org:ublue-os:staging" uupd &&
+dnf -y --enablerepo "copr:copr.fedorainfracloud.org:ublue-os:staging" install uupd &&
 	dnf -y install systemd-container
 
-dnf -y --enablerepo "copr:copr.fedorainfracloud.org:ublue-os:staging" ublue-setup-services &&
+dnf -y --enablerepo "copr:copr.fedorainfracloud.org:ublue-os:staging" install ublue-setup-services &&
 	systemctl enable check-sb-key.service
 
 dnf -y --enablerepo copr:copr.fedorainfracloud.org:ublue-os:staging swap \

--- a/build_scripts/40-services.sh
+++ b/build_scripts/40-services.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -xeuo pipefail
+
 systemctl enable rpm-ostree-countme.service
 systemctl --global enable podman-auto-update.timer
 systemctl enable rpm-ostree-countme.service


### PR DESCRIPTION
I dont know why, but these did not error out of the script?
