### PR TITLE
fix: add flathub remote

### DIFF
--- a/system_files/usr/share/ublue-os/just/60-custom.just
+++ b/system_files/usr/share/ublue-os/just/60-custom.just
@@ -1,5 +1,6 @@
 install-system-flatpaks:
     #!/usr/bin/env bash
+    flatpak remote-add --system flathub https://flathub.org/repo/flathub.flatpakrepo
     xargs flatpak --system -y install --or-update < /etc/ublue-os/system-flatpaks.list
 
 bluefin-cli:


### PR DESCRIPTION
We aren't adding the flathub remote that allow the flatpaks to be installed leading to failure to find remote packages out of the box