### PR TITLE
fix: move Just to after remove software

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -39,6 +39,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
+
+      - name: Maximize build space
+        uses: ublue-os/remove-unwanted-software@5a8b0374222a6fffddb1be9516b5fece9483bed0 # v8
+        with:
+          remove-codeql: true
+
       - name: Setup Just
         uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2
 
@@ -46,11 +52,6 @@ jobs:
         shell: bash
         run: |
           just check
-
-      - name: Maximize build space
-        uses: ublue-os/remove-unwanted-software@5a8b0374222a6fffddb1be9516b5fece9483bed0 # v8
-        with:
-          remove-codeql: true
       
       - name: Get current date
         id: date


### PR DESCRIPTION
This fixes the build as v8 of `remove-unwanted-software` removes `Just`