### PR TITLE
chore(ci): move to a weekly schedule

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: '05 10 * * *'  # 10:05am UTC everyday
+    - cron: '0 1 * * TUE'  # 
   merge_group:  
   push:
     branches:


### PR DESCRIPTION
Let's match Windows and go on Tuesdays! 

The images will still publish as we push so we can still rev fast.