### PR TITLE
fix: inherit secrets in reusable workflow

### DIFF
--- a/.github/workflows/build-dx-hwe.yml
+++ b/.github/workflows/build-dx-hwe.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   build:
     uses: ./.github/workflows/reusable-build-image.yml
+    secrets: inherit
     with:
       image-name: bluefin-dx-hwe
       flavor: dx-hwe

--- a/.github/workflows/build-dx.yml
+++ b/.github/workflows/build-dx.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   build:
     uses: ./.github/workflows/reusable-build-image.yml
+    secrets: inherit
     with:
       image-name: bluefin-dx
       flavor: dx

--- a/.github/workflows/build-hwe.yml
+++ b/.github/workflows/build-hwe.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   build:
     uses: ./.github/workflows/reusable-build-image.yml
+    secrets: inherit
     with:
       image-name: bluefin-hwe
       flavor: hwe

--- a/.github/workflows/build-regular.yml
+++ b/.github/workflows/build-regular.yml
@@ -21,5 +21,6 @@ concurrency:
 jobs:
   build:
     uses: ./.github/workflows/reusable-build-image.yml
+    secrets: inherit
     with:
       image-name: bluefin

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -27,6 +27,10 @@ on:
         required: false
         type: string
         default: "stream10"
+    secrets:
+      SIGNING_SECRET:
+        description: "The private key used to sign the image"
+        required: false
 
 env:
   IMAGE_NAME: ${{ inputs.image-name }}


### PR DESCRIPTION
We need to tell the workflow we trust the reusable workflow with our secrets.