### PR TITLE
fix: set UBLUE_CONFIG_DIR in theming script

### DIFF
--- a/system_files/etc/ublue-os/setup.json
+++ b/system_files/etc/ublue-os/setup.json
@@ -1,4 +1,4 @@
 {
   "check-secureboot": false,
-  "setup-version": 3,
+  "setup-version": 4
 }

--- a/system_files/usr/share/ublue-os/user-setup.hooks.d/10-theming.sh
+++ b/system_files/usr/share/ublue-os/user-setup.hooks.d/10-theming.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 VEN_ID="$(cat /sys/devices/virtual/dmi/id/chassis_vendor)"
 
 # Ensure custom ptyxis theme is present
@@ -8,6 +9,9 @@ mkdir -p "$PTYXIS_DIR"
 if [[ ! -f "$PTYXIS_DIR/catppuccin-dynamic.palette" ]]; then
 	cp "$PTYXIS_THEME_DIR/catppuccin-dynamic.palette" "$PTYXIS_DIR/catppuccin-dynamic.palette"
 fi
+
+UBLUE_CONFIG_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/ublue"
+mkdir -p "$UBLUE_CONFIG_DIR"
 
 if [[ ":Framework:" =~ ":$VEN_ID:" ]]; then
 	if [[ ! -f "$UBLUE_CONFIG_DIR/framework-initialized" ]]; then


### PR DESCRIPTION
This may help the Framework logo, but it may not.  This script does not set these environment variables, so the script may be failing as soon as it reaches the Framework commands.