### PR TITLE
fix(ci): ensure we always run the manifest step

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -211,6 +211,7 @@ jobs:
   manifest:
     name: Create ${{ inputs.image-name }}:${{ inputs.centos-version }} Manifest
     runs-on: ubuntu-latest
+    if: always()
     needs:
       - generate_matrix
       - build_push
@@ -222,6 +223,21 @@ jobs:
       packages: write
       id-token: write
     steps:
+      - name: Exit on failure
+        env:
+          JOBS: ${{ toJson(needs) }}
+        run: |
+          echo "Job status:"
+          echo $JOBS | jq -r 'to_entries[] | " - \(.key): \(.value.result)"'
+
+          for i in $(echo $JOBS | jq -r 'to_entries[] | .value.result'); do
+            if [ "$i" != "success" ] && [ "$i" != "skipped" ]; then
+              echo ""
+              echo "Status check not okay!"
+              exit 1
+            fi
+          done
+
       - name: Install dependencies
         run: |
           dnf install -y \

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -210,7 +210,6 @@ jobs:
 
   manifest:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     needs:
       - build_push
     container:
@@ -268,6 +267,7 @@ jobs:
             containers.bootc=1
 
       - name: Fetch Build Outputs
+        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:
           pattern: ${{ env.IMAGE_NAME }}-*
@@ -275,6 +275,7 @@ jobs:
           path: /tmp/artifacts
 
       - name: Load Outputs
+        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         id: load-outputs
         run: |
           DIGESTS_JSON=$(jq -n '{}')
@@ -288,12 +289,14 @@ jobs:
           echo "DIGESTS_JSON=$(echo $DIGESTS_JSON | jq -c '.')" >> $GITHUB_OUTPUT
 
       - name: Create Manifest
+        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         id: create-manifest
         run: |
           podman manifest create ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
           echo "MANIFEST=${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}" >> $GITHUB_OUTPUT
 
       - name: Populate Manifest
+        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         env:
           MANIFEST: ${{ steps.create-manifest.outputs.MANIFEST }}
           DIGESTS_JSON: ${{ steps.load-outputs.outputs.DIGESTS_JSON }}
@@ -316,9 +319,11 @@ jobs:
           done <<< "$LABELS"
 
       - name: Login to GHCR
+        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         run: echo ${{ secrets.GITHUB_TOKEN }} | podman login -u ${{ github.actor }} --password-stdin ghcr.io
 
       - name: Push Manifest
+        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         env:
           MANIFEST: ${{ steps.create-manifest.outputs.MANIFEST }}
           TAGS: ${{ steps.metadata.outputs.tags }}

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -209,6 +209,7 @@ jobs:
             /tmp/outputs/digests/*.txt
 
   manifest:
+    name: Create ${{ inputs.image-name }}:${{ inputs.centos-version }} Manifest
     runs-on: ubuntu-latest
     needs:
       - generate_matrix

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -211,6 +211,7 @@ jobs:
   manifest:
     runs-on: ubuntu-latest
     needs:
+      - generate_matrix
       - build_push
     container:
       image: quay.io/fedora/fedora:41@sha256:991a06b2425c13613ef8ace721a9055e52a64f65cd96c2b18c72bde43fe1308b

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -223,6 +223,15 @@ jobs:
       packages: write
       id-token: write
     steps:
+      - name: Install dependencies
+        run: |
+          dnf install -y \
+            jq \
+            git
+
+          dnf copr enable -y rhcontainerbot/podman-next
+          dnf install -y podman
+
       - name: Exit on failure
         env:
           JOBS: ${{ toJson(needs) }}
@@ -237,15 +246,6 @@ jobs:
               exit 1
             fi
           done
-
-      - name: Install dependencies
-        run: |
-          dnf install -y \
-            jq \
-            git
-
-          dnf copr enable -y rhcontainerbot/podman-next
-          dnf install -y podman
 
       - name: Get current date
         id: date


### PR DESCRIPTION
This should allow us to target this job as part of the repository rulesets.
I feel GitHub may not be working properly because this is always skipped in PRs.