### PR TITLE
chore: remove boxbuddy from non-dx images

### DIFF
--- a/build_scripts/26-packages-post.sh
+++ b/build_scripts/26-packages-post.sh
@@ -15,6 +15,10 @@ rm -f /usr/share/pixmaps/faces/* || echo "Expected directory deletion to fail"
 mv /usr/share/pixmaps/faces/bluefin/* /usr/share/pixmaps/faces
 rm -rf /usr/share/pixmaps/faces/bluefin
 
+# This should only be enabled on `-dx`
+sed -i "/^show-boxbuddy=.*/d" /etc/dconf/db/distro.d/04-bluefin-logomenu-extension
+sed -i "/^show-boxbuddy=.*/d" /usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+
 # The compose repos we used during the build are point in time repos that are
 # not updated, so we don't want to leave them enabled.
 # FIXME: figure out why this is not working

--- a/build_scripts/26-packages-post.sh
+++ b/build_scripts/26-packages-post.sh
@@ -18,6 +18,7 @@ rm -rf /usr/share/pixmaps/faces/bluefin
 # This should only be enabled on `-dx`
 sed -i "/^show-boxbuddy=.*/d" /etc/dconf/db/distro.d/04-bluefin-logomenu-extension
 sed -i "/^show-boxbuddy=.*/d" /usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+sed -i "/.*io.github.dvlv.boxbuddyrs.*/d" /etc/ublue-os/system-flatpaks.list
 
 # The compose repos we used during the build are point in time repos that are
 # not updated, so we don't want to leave them enabled.

--- a/build_scripts/overrides/dx/05-dconf.sh
+++ b/build_scripts/overrides/dx/05-dconf.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+# FIXME: make this part prettier, i dont know how to do it right now
+cat >/etc/dconf/db/distro.d/05-dx-logomenu-extension <<EOF
+[org/gnome/shell/extensions/Logo-menu]
+show-boxbuddy=true
+EOF
+
+cat >/usr/share/glib-2.0/schemas/zz1-dx-modifications.gschema.override <<EOF
+[org/gnome/shell/extensions/Logo-menu]
+show-boxbuddy=true
+EOF

--- a/build_scripts/overrides/dx/05-dconf.sh
+++ b/build_scripts/overrides/dx/05-dconf.sh
@@ -12,3 +12,5 @@ cat >/usr/share/glib-2.0/schemas/zz1-dx-modifications.gschema.override <<EOF
 [org/gnome/shell/extensions/Logo-menu]
 show-boxbuddy=true
 EOF
+
+echo "io.github.dvlv.boxbuddyrs" >> /etc/ublue-os/system-flatpaks.list 


### PR DESCRIPTION
Port of https://github.com/ublue-os/bluefin/pull/1994/files