### PR TITLE
fix: ensure suspend-then-hibernate is the default sleep option

### DIFF
--- a/build_scripts/40-services.sh
+++ b/build_scripts/40-services.sh
@@ -6,7 +6,7 @@ set -xeuo pipefail
 sed -i 's/#HandleLidSwitch=.*/HandleLidSwitch=suspend-then-hibernate/g' /usr/lib/systemd/logind.conf
 sed -i 's/#HandleLidSwitchDocked=.*/HandleLidSwitchDocked=suspend-then-hibernate/g' /usr/lib/systemd/logind.conf
 sed -i 's/#HandleLidSwitchExternalPower=.*/HandleLidSwitchExternalPower=suspend-then-hibernate/g' /usr/lib/systemd/logind.conf
-sed -i 's/#SleepOperation=.*/SleepOperation=suspend-then-hibernate suspend/g' /usr/lib/systemd/logind.conf
+sed -i 's/#SleepOperation=.*/SleepOperation=suspend-then-hibernate/g' /usr/lib/systemd/logind.conf
 systemctl enable gdm.service
 systemctl enable fwupd.service
 # enable systemd-resolved for proper name resolution


### PR DESCRIPTION
This just makes _sure_ suspend-then-hibernation will be the default behavior when closing the lid. Im not completely sure the current approach works without this patch
