### PR TITLE
fix: make build.sh less verbose so we can click on the arrows

### DIFF
--- a/build_scripts/build.sh
+++ b/build_scripts/build.sh
@@ -3,7 +3,7 @@
 # This file needs to exist otherwise running this in a RUN label makes it so bash strict mode doesnt work.
 # Thus leading to silent failures
 
-set -xeuo pipefail
+set -euo pipefail
 
 # Do not rely on any of these scripts existing in a specific path
 # Make the names as descriptive as possible and everything that uses dnf for package installation/removal should have `packages-` as a prefix.


### PR DESCRIPTION
This is more of an accessibility change, I personally cannot ever see the little `>` icon there on the build logs