### PR TITLE
fix: make signing come as late as possible on the build

### DIFF
--- a/build_scripts/20-packages.sh
+++ b/build_scripts/20-packages.sh
@@ -22,11 +22,7 @@ dnf -y install \
 # We do, however, leave crb and EPEL enabled by default.
 
 # RPMS from Ublue-os config
-dnf -y install /tmp/rpms/ublue-os-{udev-rules,luks,signing}.noarch.rpm
-# ublue-os-signing incorrectly puts files under /usr/etc and bootc container lint gets mad at this.
-# FIXME: dear lord fix this upstream https://github.com/ublue-os/config/pull/311
-cp -av /usr/etc /etc
-rm -rvf /usr/etc
+dnf -y install /tmp/rpms/ublue-os-{udev-rules,luks}.noarch.rpm
 
 cp -r /usr/share/ublue-os/just /tmp/just
 # Focefully install ujust without powerstat while we don't have it on EPEL

--- a/build_scripts/cleanup.sh
+++ b/build_scripts/cleanup.sh
@@ -8,6 +8,13 @@ set -euo pipefail
 # Hide Desktop Files. Hidden removes mime associations
 sed -i 's@\[Desktop Entry\]@\[Desktop Entry\]\nHidden=true@g' /usr/share/applications/fish.desktop
 
+# Signing needs to be as late as possible so that it wont be overwritten by anything, ever.
+dnf -y install /tmp/rpms/ublue-os-signing.noarch.rpm
+# ublue-os-signing incorrectly puts files under /usr/etc and bootc container lint gets mad at this.
+# FIXME: dear lord fix this upstream https://github.com/ublue-os/config/pull/311
+cp -av /usr/etc /etc
+rm -rvf /usr/etc
+
 # Image-layer cleanup
 shopt -s extglob
 


### PR DESCRIPTION
Otherwise this can be overwritten by something else on the build and make ISOs literally just not work