### PR TITLE
fix: make signing actually work!

### DIFF
--- a/build_scripts/build.sh
+++ b/build_scripts/build.sh
@@ -23,7 +23,7 @@ copy_systemfiles_for() {
 	WHAT=$1
 	shift
 	printf "::group:: ===%s-file-copying===\n" "$WHAT"
-	cp -av "/var/tmp/system_files_overrides/$WHAT/." /
+	cp -avf "/var/tmp/system_files_overrides/$WHAT/." /
 	printf "::endgroup::\n"
 }
 

--- a/build_scripts/cleanup.sh
+++ b/build_scripts/cleanup.sh
@@ -12,7 +12,7 @@ sed -i 's@\[Desktop Entry\]@\[Desktop Entry\]\nHidden=true@g' /usr/share/applica
 dnf -y install /tmp/rpms/ublue-os-signing.noarch.rpm
 # ublue-os-signing incorrectly puts files under /usr/etc and bootc container lint gets mad at this.
 # FIXME: dear lord fix this upstream https://github.com/ublue-os/config/pull/311
-cp -av /usr/etc /etc
+cp -avf /usr/etc/. /etc
 rm -rvf /usr/etc
 
 # Image-layer cleanup


### PR DESCRIPTION
Typos were making it so the signing wasnt getting applied at all, it was copying /usr/etc to... /etc/etc...