### PR TITLE
fix: sign manifest with cosign

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -366,7 +366,16 @@ jobs:
     needs: manifest
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     steps:
+      - name: Login to GHCR
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login -u ${{ github.actor }} --password-stdin ghcr.io
+          echo ${{ secrets.GITHUB_TOKEN }} | podman login -u ${{ github.actor }} --password-stdin ghcr.io
+
       - name: Install Cosign
         uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
 

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -342,6 +342,7 @@ jobs:
 
       - name: Push Manifest
         if: github.event_name != 'pull_request'
+        id: push_manifest
         env:
           MANIFEST: ${{ steps.create-manifest.outputs.MANIFEST }}
           TAGS: ${{ steps.metadata.outputs.tags }}
@@ -349,5 +350,23 @@ jobs:
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
         run: |
           while IFS= read -r tag; do
-            podman manifest push --all=false $MANIFEST $IMAGE_REGISTRY/$IMAGE_NAME:$tag
+            podman manifest push --all=false --digestfile=/tmp/digestfile $MANIFEST $IMAGE_REGISTRY/$IMAGE_NAME:$tag
           done <<< "$TAGS"
+
+          DIGEST=$(cat digestfile)
+          echo "DIGEST=$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
+        if: github.event_name != 'pull_request'
+
+      - name: Sign Manifest
+        if: github.event_name != 'pull_request'
+        run: |
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY $IMAGE_REGISTRY/$IMAGE_NAME@$DIGEST
+        env:
+          DIGEST: ${{ steps.push_manifest.outputs.DIGEST }}
+          IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          COSIGN_EXPERIMENTAL: false
+          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -222,6 +222,9 @@ jobs:
       contents: read
       packages: write
       id-token: write
+    outputs:
+      image: ${{ steps.push_manifest.outputs.IMAGE }}
+      digest: ${{ steps.push_manifest.outputs.DIGEST }}
     steps:
       - name: Install dependencies
         run: |
@@ -355,21 +358,23 @@ jobs:
 
           DIGEST=$(cat /tmp/digestfile)
           echo "DIGEST=$DIGEST" >> $GITHUB_OUTPUT
+          echo "IMAGE=$IMAGE_REGISTRY/$IMAGE_NAME" >> $GITHUB_OUTPUT
+
+  # Cosign throws errors when ran inside the Fedora container for one reason or another
+  # so we move this to another step in order to run on Ubuntu
+  sign:
+    needs: manifest
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
 
       - name: Sign Manifest
-        if: github.event_name != 'pull_request'
         run: |
-          podman run --rm \
-            --env COSIGN_PRIVATE_KEY="${COSIGN_PRIVATE_KEY}" \
-            --env IMAGE_REGISTRY="${IMAGE_REGISTRY}" \
-            --env IMAGE_NAME="${IMAGE_NAME}" \
-            --env DIGEST="${DIGEST}" \
-            --env COSIGN_EXPERIMENTAL=false \
-            cgr.dev/chainguard/cosign:latest \
-            sign -y --key env://COSIGN_PRIVATE_KEY "${IMAGE_REGISTRY}/${IMAGE_NAME}@${DIGEST}"
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY $IMAGE_REGISTRY/$IMAGE_NAME@$DIGEST
         env:
-          DIGEST: ${{ steps.push_manifest.outputs.DIGEST }}
-          IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
-          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          DIGEST: ${{ needs.manifest.outputs.digest }}
+          IMAGE: ${{ needs.manifest.outputs.image }}
           COSIGN_EXPERIMENTAL: false
           COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -356,14 +356,17 @@ jobs:
           DIGEST=$(cat /tmp/digestfile)
           echo "DIGEST=$DIGEST" >> $GITHUB_OUTPUT
 
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
-        if: github.event_name != 'pull_request'
-
       - name: Sign Manifest
         if: github.event_name != 'pull_request'
         run: |
-          cosign sign -y --key env://COSIGN_PRIVATE_KEY $IMAGE_REGISTRY/$IMAGE_NAME@$DIGEST
+          podman run --rm \
+            --env COSIGN_PRIVATE_KEY="${COSIGN_PRIVATE_KEY}" \
+            --env IMAGE_REGISTRY="${IMAGE_REGISTRY}" \
+            --env IMAGE_NAME="${IMAGE_NAME}" \
+            --env DIGEST="${DIGEST}" \
+            --env COSIGN_EXPERIMENTAL=false \
+            chainguard/cosign:latest \
+            sign -y --key env://COSIGN_PRIVATE_KEY "${IMAGE_REGISTRY}/${IMAGE_NAME}@${DIGEST}"
         env:
           DIGEST: ${{ steps.push_manifest.outputs.DIGEST }}
           IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -365,7 +365,7 @@ jobs:
             --env IMAGE_NAME="${IMAGE_NAME}" \
             --env DIGEST="${DIGEST}" \
             --env COSIGN_EXPERIMENTAL=false \
-            chainguard/cosign:latest \
+            cgr.dev/chainguard/cosign:latest \
             sign -y --key env://COSIGN_PRIVATE_KEY "${IMAGE_REGISTRY}/${IMAGE_NAME}@${DIGEST}"
         env:
           DIGEST: ${{ steps.push_manifest.outputs.DIGEST }}

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -353,7 +353,7 @@ jobs:
             podman manifest push --all=false --digestfile=/tmp/digestfile $MANIFEST $IMAGE_REGISTRY/$IMAGE_NAME:$tag
           done <<< "$TAGS"
 
-          DIGEST=$(cat digestfile)
+          DIGEST=$(cat /tmp/digestfile)
           echo "DIGEST=$DIGEST" >> $GITHUB_OUTPUT
 
       - name: Install Cosign

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -372,7 +372,7 @@ jobs:
 
       - name: Sign Manifest
         run: |
-          cosign sign -y --key env://COSIGN_PRIVATE_KEY $IMAGE_REGISTRY/$IMAGE_NAME@$DIGEST
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY $IMAGE@$DIGEST
         env:
           DIGEST: ${{ needs.manifest.outputs.digest }}
           IMAGE: ${{ needs.manifest.outputs.image }}


### PR DESCRIPTION
--enforce-container-sigpolicy is failing due to a missing signature.

This PR signs the manifests as well as the image, which should allow us to enforce signatures during rebases and updates.

Due to running the manifest step in a container, and Cosign not working well in said container, I've moved the sign step to a separate job which is completed after pushing the manifest.