### PR TITLE
fix: use inputs for single-arch images

### DIFF
--- a/.github/workflows/build-gdx.yml
+++ b/.github/workflows/build-gdx.yml
@@ -20,3 +20,4 @@ jobs:
     with:
       image-name: bluefin-gdx
       flavor: gdx
+      platforms: adm64

--- a/.github/workflows/build-gdx.yml
+++ b/.github/workflows/build-gdx.yml
@@ -20,4 +20,4 @@ jobs:
     with:
       image-name: bluefin-gdx
       flavor: gdx
-      platforms: adm64
+      platforms: amd64

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -54,14 +54,9 @@ jobs:
           IFS=',' read -r -a platforms <<< "${{ inputs.platforms }}"
 
           MATRIX="{\"include\":[]}"
-          if [ "${{ inputs.flavor }}" == "gdx" ] ; then
-            # We explicitly only support Nvidia on x86 for now.
-            MATRIX=$(echo $MATRIX | jq ".include += [{\"platform\": \"amd64\"}]")
-          else
-            for platform in "${platforms[@]}"; do
-              MATRIX=$(echo $MATRIX | jq ".include += [{\"platform\": \"$platform\"}]")
-            done
-          fi
+          for platform in "${platforms[@]}"; do
+            MATRIX=$(echo $MATRIX | jq ".include += [{\"platform\": \"$platform\"}]")
+          done
           echo "matrix=$(echo $MATRIX | jq -c '.')" >> $GITHUB_OUTPUT
 
   build_push:


### PR DESCRIPTION
This is easier than having conditions in the script.