### PR TITLE
fix: make nvidia-open kernel modules build on container build

### DIFF
--- a/build_scripts/00-workarounds.sh
+++ b/build_scripts/00-workarounds.sh
@@ -9,7 +9,8 @@ set -xeuo pipefail
 # have strict NVR requirements.
 curl --retry 3 -Lo "/etc/yum.repos.d/compose.repo" "https://gitlab.com/redhat/centos-stream/containers/bootc/-/raw/c${MAJOR_VERSION_NUMBER}s/cs.repo"
 sed -r \
-	-e 's@(baseos|appstream)@&-compose@' \
+	-e 's@\[rhel-10-for-\$basearch-@[@' \
+	-e 's@-rpms\]@-compose]@' \
 	-e 's@- (BaseOS|AppStream)@& - Compose@' \
 	-e 's@/usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official@/etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial-SHA256@' \
 	-i /etc/yum.repos.d/compose.repo

--- a/build_scripts/overrides/x86_64/gdx/20-nvidia.sh
+++ b/build_scripts/overrides/x86_64/gdx/20-nvidia.sh
@@ -8,12 +8,13 @@ NVIDIA_DISTRO="rhel9"
 # These are necessary for building the nvidia drivers
 # DKMS is provided by EPEL
 # Also make sure the kernel is locked before this is run whenever the kernel updates
-# kernel-devel might pull in an entire new kernel
-dnf -y install kernel-devel kernel-devel-matched kernel-headers dkms
+# kernel-devel might pull in an entire new kernel if you dont do
+dnf -y install kernel-devel kernel-devel-matched kernel-headers dkms gcc-c++
 
 dnf config-manager --add-repo "https://developer.download.nvidia.com/compute/cuda/repos/${NVIDIA_DISTRO}/$(arch)/cuda-${NVIDIA_DISTRO}.repo"
 dnf clean expire-cache
 NVIDIA_DRIVER_DIRECTORY=$(mktemp -d)
+NVIDIA_DRIVER_FLAVOR=nvidia-open
 
 # EGL-gbm and EGL-wayland fail to install because of conflicts with each other
 dnf download egl-gbm egl-wayland --destdir=$NVIDIA_DRIVER_DIRECTORY
@@ -22,7 +23,28 @@ rpm -ivh $NVIDIA_DRIVER_DIRECTORY/*.rpm --nodeps --force
 dnf -y install --nogpgcheck \
   -x egl-wayland \
   -x egl-gbm \
-  nvidia-driver{,-cuda} kmod-nvidia-open-dkms
+  nvidia-driver{,-cuda} kmod-$NVIDIA_DRIVER_FLAVOR-dkms
+
+KERNEL_SUFFIX=""
+QUALIFIED_KERNEL="$(rpm -qa | grep -P 'kernel-(|'"$KERNEL_SUFFIX"'-)(\d+\.\d+\.\d+)' | sed -E 's/kernel-(|'"$KERNEL_SUFFIX"'-)//')"
+
+# The nvidia-open driver tries to use the kernel from the host. (uname -r), just override it and let it do whatever otherwise
+cat >/tmp/fake-uname <<EOF
+#!/usr/bin/env bash
+
+if [ "\$1" == "-r" ] ; then
+  echo ${QUALIFIED_KERNEL}
+  exit 0
+fi
+
+exec /usr/bin/uname \$@
+EOF
+install -Dm0755 /tmp/fake-uname /tmp/bin/uname
+
+NVIDIA_DRIVER_VERSION=$(rpm -q "nvidia-driver" --queryformat '%{VERSION}')
+# PATH modification for fake-uname
+PATH=/tmp/bin:$PATH dkms install -m $NVIDIA_DRIVER_FLAVOR -v $NVIDIA_DRIVER_VERSION -k $QUALIFIED_KERNEL
+cat /var/lib/dkms/nvidia-open/$NVIDIA_DRIVER_VERSION/build/make.log || echo "Expected failure"
 
 cat >/usr/lib/modprobe.d/00-nouveau-blacklist.conf <<EOF
 blacklist nouveau
@@ -34,8 +56,5 @@ kargs = ["rd.driver.blacklist=nouveau", "modprobe.blacklist=nouveau", "nvidia-dr
 match-architectures = ["x86_64"]
 EOF
 
-
 # Make sure initramfs is rebuilt after nvidia drivers or kernel replacement
-KERNEL_SUFFIX=""
-QUALIFIED_KERNEL="$(rpm -qa | grep -P 'kernel-(|'"$KERNEL_SUFFIX"'-)(\d+\.\d+\.\d+)' | sed -E 's/kernel-(|'"$KERNEL_SUFFIX"'-)//')"
 /usr/bin/dracut --no-hostonly --kver "$QUALIFIED_KERNEL" --reproducible --zstd -v -f


### PR DESCRIPTION
This was the least fun PR ever. Every part of it (except maybe the compose fix on 00-workarounds) was _necessary_ to getting this working