### PR TITLE
feat: add flathub by default on-image

### DIFF
--- a/build_scripts/26-packages-post.sh
+++ b/build_scripts/26-packages-post.sh
@@ -25,6 +25,10 @@ sed -i "/.*io.github.dvlv.boxbuddyrs.*/d" /etc/ublue-os/system-flatpaks.list
 # FIXME: figure out why this is not working
 # dnf config-manager --set-disabled baseos-compose,appstream-compose
 
+# Add Flathub by default
+mkdir -p /etc/flatpak/remotes.d
+curl --retry 3 -o /etc/flatpak/remotes.d/flathub.flatpakrepo "https://dl.flathub.org/repo/flathub.flatpakrepo"
+
 # Generate initramfs image after installing Bluefin branding because of Plymouth subpackage
 # Add resume module so that hibernation works
 echo "add_dracutmodules+=\" resume \"" >/etc/dracut.conf.d/resume.conf


### PR DESCRIPTION
This is so that we dont _need_ the ujust command for people to actually be able to use the GNOME store