### PR TITLE
fix: disable vscode update dialog

### DIFF
--- a/system_files_overrides/dx/etc/skel/.config/Code/User/settings.json
+++ b/system_files_overrides/dx/etc/skel/.config/Code/User/settings.json
@@ -1,4 +1,5 @@
 {
     "window.titleBarStyle": "custom",
     "editor.fontFamily": "'Cascadia Code', 'Droid Sans Mono', 'monospace', monospace"
+    "update.mode": "none"
 }

--- a/system_files_overrides/dx/etc/skel/.config/Code/User/settings.json
+++ b/system_files_overrides/dx/etc/skel/.config/Code/User/settings.json
@@ -1,5 +1,5 @@
 {
     "window.titleBarStyle": "custom",
-    "editor.fontFamily": "'Cascadia Code', 'Droid Sans Mono', 'monospace', monospace"
+    "editor.fontFamily": "'Cascadia Code', 'Droid Sans Mono', 'monospace', monospace",
     "update.mode": "none"
 }


### PR DESCRIPTION
This stops annoying the user when vscode updates inbetween a weekly build. Matches bluefin:stable