### PR TITLE
feat: use built-in rpm-ostree rechunking for rechunking

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -121,24 +121,15 @@ jobs:
 
           sudo $just build "${IMAGE_NAME}" "${DEFAULT_TAG}" "$ENABLE_DX" "$ENABLE_HWE" "$ENABLE_GDX"
 
-      - name: Run Rechunker
-        if: github.event_name != 'pull_request'
-        id: rechunk
-        uses: hhd-dev/rechunk@341e1298e827bc60cfe19d71539ca42d08c89cfe # v1.1.3
-        with:
-          rechunk: "ghcr.io/hhd-dev/rechunk:v1.1.3"
-          ref: "localhost/${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}"
-          prev-ref: "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}"
-          skip_compression: true
-          version: ${{ env.CENTOS_VERSION }}
-
-      - name: Load Image
+      - name: Rechunk and Tag
         if: github.event_name != 'pull_request'
         id: load
         run: |
-          IMAGE=$(sudo podman pull ${{ steps.rechunk.outputs.ref }})
-          sudo rm -rf ${{ steps.rechunk.outputs.location }}
-          sudo podman image tag $IMAGE ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}
+          set -x
+          just=$(which just)
+          
+          sudo $just rechunk "${IMAGE_NAME}" "${DEFAULT_TAG}"
+          sudo podman image tag "$IMAGE_NAME:${DEFAULT_TAG}" "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}"
 
           IMAGE=${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}
           IMAGE_DIGEST=$(sudo podman image inspect --format '{{.Digest}}' $IMAGE)

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -121,13 +121,13 @@ jobs:
 
           sudo $just build "${IMAGE_NAME}" "${DEFAULT_TAG}" "$ENABLE_DX" "$ENABLE_HWE" "$ENABLE_GDX"
 
-      - name: Rechunk and Tag
-        if: github.event_name != 'pull_request'
+      - name: Rechunk and Tag image
+        # if: github.event_name != 'pull_request'
         id: load
         run: |
           set -x
           just=$(which just)
-          
+
           sudo $just rechunk "${IMAGE_NAME}" "${DEFAULT_TAG}"
           sudo podman image tag "$IMAGE_NAME:${DEFAULT_TAG}" "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}"
 

--- a/build_scripts/build.sh
+++ b/build_scripts/build.sh
@@ -24,6 +24,7 @@ copy_systemfiles_for() {
 	shift
 	printf "::group:: ===%s-file-copying===\n" "$WHAT"
 	cp -avf "/var/tmp/system_files_overrides/$WHAT/." /
+	rm -f /.gitkeep
 	printf "::endgroup::\n"
 }
 


### PR DESCRIPTION
This should use the built-in rpm-ostree rechunking instead of using hhd-dev/rechunk for the image rechunking. This should both remove a big dependency and maybe speed up build times with new versions