### PR TITLE
feat: add CentOS version number tags

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -38,6 +38,7 @@ env:
   IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}"
   DEFAULT_TAG: "lts"
   CENTOS_VERSION: ${{ inputs.centos-version }}
+  CENTOS_VERSION_NUMBER: ${{ inputs.centos-version | tr -d -c 0-9 }}
   PLATFORMS: ${{ inputs.platforms }}
 
 jobs:
@@ -272,6 +273,8 @@ jobs:
             type=raw,value=lts-{{date 'YYYYMMDD'}}
             type=raw,value=${{ env.CENTOS_VERSION }}
             type=raw,value=${{ env.CENTOS_VERSION }}.{{date 'YYYYMMDD'}}
+            type=raw,value=${{ env.CENTOS_VERSION_NUMBER }}
+            type=raw,value=${{ env.CENTOS_VERSION_NUMBER }}.{{date 'YYYYMMDD'}}
             type=ref,event=pr
           labels: |
             io.artifacthub.package.readme-url=https://raw.githubusercontent.com/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}/refs/heads/main/README.md

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -38,7 +38,6 @@ env:
   IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}"
   DEFAULT_TAG: "lts"
   CENTOS_VERSION: ${{ inputs.centos-version }}
-  CENTOS_VERSION_NUMBER: ${{ inputs.centos-version | tr -d -c 0-9 }}
   PLATFORMS: ${{ inputs.platforms }}
 
 jobs:
@@ -263,6 +262,12 @@ jobs:
           # https://artifacthub.io/docs/topics/repositories/container-images/
           # https://linux.die.net/man/1/date
           echo "date=$(date -u +%Y\-%m\-%d\T%H\:%M\:%S\Z)" >> $GITHUB_OUTPUT
+
+      - name: Extract numbers from input
+        id: extract-numbers
+        run: |
+          numbers_only=$(echo "${{ env.CENTOS_VERSION }}" | tr -cd '0-9')
+          echo "CENTOS_VERSION_NUMBER=$numbers_only" >> $GITHUB_ENV
 
       - name: Image Metadata
         uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 # v5


### PR DESCRIPTION
This adds the centos version number as a tag, like `bluefin:10`, and `bluefin:10.YYYYMMDD`