### PR TITLE
fix: kernel package skews because of compose repos getting disabled too early in build

### DIFF
--- a/build_scripts/26-packages-post.sh
+++ b/build_scripts/26-packages-post.sh
@@ -20,10 +20,6 @@ sed -i "/^show-boxbuddy=.*/d" /etc/dconf/db/distro.d/04-bluefin-logomenu-extensi
 sed -i "/^show-boxbuddy=.*/d" /usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
 sed -i "/.*io.github.dvlv.boxbuddyrs.*/d" /etc/ublue-os/system-flatpaks.list
 
-# The compose repos we used during the build are point in time repos that are
-# not updated, so we don't want to leave them enabled.
-dnf config-manager --set-disabled baseos-compose,appstream-compose
-
 # Add Flathub by default
 mkdir -p /etc/flatpak/remotes.d
 curl --retry 3 -o /etc/flatpak/remotes.d/flathub.flatpakrepo "https://dl.flathub.org/repo/flathub.flatpakrepo"

--- a/build_scripts/cleanup.sh
+++ b/build_scripts/cleanup.sh
@@ -8,6 +8,10 @@ set -xeuo pipefail
 # Hide Desktop Files. Hidden removes mime associations
 sed -i 's@\[Desktop Entry\]@\[Desktop Entry\]\nHidden=true@g' /usr/share/applications/fish.desktop
 
+# The compose repos we used during the build are point in time repos that are
+# not updated, so we don't want to leave them enabled.
+dnf config-manager --set-disabled baseos-compose,appstream-compose
+
 # Signing needs to be as late as possible so that it wont be overwritten by anything, ever.
 dnf -y install /tmp/rpms/ublue-os-signing.noarch.rpm
 # ublue-os-signing incorrectly puts files under /usr/etc and bootc container lint gets mad at this.

--- a/build_scripts/overrides/x86_64/gdx/20-nvidia.sh
+++ b/build_scripts/overrides/x86_64/gdx/20-nvidia.sh
@@ -43,7 +43,7 @@ install -Dm0755 /tmp/fake-uname /tmp/bin/uname
 
 NVIDIA_DRIVER_VERSION=$(rpm -q "nvidia-driver" --queryformat '%{VERSION}')
 # PATH modification for fake-uname
-PATH=/tmp/bin:$PATH dkms install -m $NVIDIA_DRIVER_FLAVOR -v $NVIDIA_DRIVER_VERSION -k $QUALIFIED_KERNEL
+PATH=/tmp/bin:$PATH dkms --force install -m $NVIDIA_DRIVER_FLAVOR -v $NVIDIA_DRIVER_VERSION -k $QUALIFIED_KERNEL
 cat /var/lib/dkms/nvidia-open/$NVIDIA_DRIVER_VERSION/build/make.log || echo "Expected failure"
 
 cat >/usr/lib/modprobe.d/00-nouveau-blacklist.conf <<EOF


### PR DESCRIPTION
This should make the GDX builds happy and the changelog should run again