### PR TITLE
fix: use epel-release from centos repos

### DIFF
--- a/build_scripts/15-packages-image-base.sh
+++ b/build_scripts/15-packages-image-base.sh
@@ -12,8 +12,8 @@ dnf -y update
 dnf -y install 'dnf-command(versionlock)'
 dnf versionlock add kernel kernel-devel kernel-devel-matched kernel-core kernel-modules kernel-modules-core kernel-modules-extra kernel-uki-virt
 
+dnf -y install epel-release
 dnf config-manager --set-enabled crb
-dnf -y install "https://dl.fedoraproject.org/pub/epel/epel-release-latest-$MAJOR_VERSION_NUMBER.noarch.rpm"
 
 # Multimidia codecs
 dnf -y install @multimedia gstreamer1-plugins-{bad-free,bad-free-libs,good,base} lame{,-libs} libjxl


### PR DESCRIPTION
This fixes github actions not being able to fetch the epel-release rpm from the specific URL we are fetching it from.