### PR TITLE
chore: remove unnecessary workaround on global environment and add note about other workarounds

### DIFF
--- a/system_files/etc/environment
+++ b/system_files/etc/environment
@@ -1,3 +1,4 @@
+# NOTE: Necessary due to cursor being laggy with VRR on GNOME 47
 MUTTER_DEBUG_FORCE_KMS_MODE=simple
-MUTTER_DEBUG_KMS_THREAD_TYPE=user
+# NOTE: Makes GNOME slightly faster
 GNOME_SHELL_SLOWDOWN_FACTOR=0.8


### PR DESCRIPTION
We can just remove the `FOOBAR=user` part because its already fixed upstream, probably was just necessary for a tiny bit of time. The other ones are still necessary