### PR TITLE
feat: add nvtop and use epel version of staging copr for packages

### DIFF
--- a/build_scripts/20-packages.sh
+++ b/build_scripts/20-packages.sh
@@ -41,7 +41,7 @@ dnf config-manager --set-disabled "tailscale-stable"
 dnf -y --enablerepo "tailscale-stable" install \
 	tailscale
 
-dnf config-manager --add-repo "https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/centos-stream-$MAJOR_VERSION_NUMBER/ublue-os-staging-centos-stream-$MAJOR_VERSION_NUMBER.repo"
+dnf config-manager --add-repo "https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/epel-$MAJOR_VERSION_NUMBER/ublue-os-staging-epel-$MAJOR_VERSION_NUMBER.repo"
 dnf config-manager --set-disabled "copr:copr.fedorainfracloud.org:ublue-os:staging"
 dnf -y --enablerepo copr:copr.fedorainfracloud.org:ublue-os:staging install \
 	-x bluefin-logos \

--- a/build_scripts/overrides/x86_64/gdx/30-packages.sh
+++ b/build_scripts/overrides/x86_64/gdx/30-packages.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 
-dnf -y install uv
+dnf -y install \
+  uv \
+  nvtop


### PR DESCRIPTION
This makes it so we can use the EPEL version instead of raw centos-stream for building our packages, makes it so we can build A LOT more stuff on our copr instead of being just stuff restricted to the centos repos. Itll also allow us to just disable the centos-stream chroot too, so thats pretty nice!