### PR TITLE
chore: move COPR packages to new `ublue-os` coprs

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,4 @@
 ARG MAJOR_VERSION="${MAJOR_VERSION:-stream10}"
-FROM ghcr.io/ublue-os/config:latest@sha256:e45ff5faf342ea871a88b3e1c86b7cd517545d53fdd88e23ca5a3d56e79b9440 AS config
 FROM quay.io/centos-bootc/centos-bootc:$MAJOR_VERSION
 
 # ARM should be handled by $(arch)
@@ -15,4 +14,4 @@ COPY system_files /
 COPY system_files_overrides /var/tmp/system_files_overrides
 COPY build_scripts /var/tmp/build_scripts
 
-RUN --mount=type=tmpfs,dst=/tmp --mount=type=bind,from=config,src=/rpms,dst=/tmp/rpms /var/tmp/build_scripts/build.sh
+RUN --mount=type=tmpfs,dst=/tmp /var/tmp/build_scripts/build.sh

--- a/build_scripts/20-packages.sh
+++ b/build_scripts/20-packages.sh
@@ -41,18 +41,26 @@ dnf config-manager --set-disabled "tailscale-stable"
 dnf -y --enablerepo "tailscale-stable" install \
 	tailscale
 
+dnf config-manager --add-repo "https://copr.fedorainfracloud.org/coprs/ublue-os/bluefin/repo/epel-$MAJOR_VERSION_NUMBER/ublue-os-bluefin-epel-$MAJOR_VERSION_NUMBER.repo"
+dnf config-manager --set-disabled "copr:copr.fedorainfracloud.org:ublue-os:bluefin" \
+	-x bluefin-logos \
+	bluefin-*
+
+dnf -y --enablerepo copr:copr.fedorainfracloud.org:ublue-os:bluefin swap \
+	centos-logos bluefin-logos
+
+dnf config-manager --add-repo "https://copr.fedorainfracloud.org/coprs/ublue-os/packages/repo/epel-$MAJOR_VERSION_NUMBER/ublue-os-packages-epel-$MAJOR_VERSION_NUMBER.repo"
+dnf config-manager --set-disabled "copr:copr.fedorainfracloud.org:ublue-os:packages"
+dnf -y --enablerepo copr:copr.fedorainfracloud.org:ublue-os:packages install \
+	ublue-{motd,fastfetch,brew,bling,rebase-helper,setup-services} \
+	uupd
+
 dnf config-manager --add-repo "https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/epel-$MAJOR_VERSION_NUMBER/ublue-os-staging-epel-$MAJOR_VERSION_NUMBER.repo"
 dnf config-manager --set-disabled "copr:copr.fedorainfracloud.org:ublue-os:staging"
 dnf -y --enablerepo copr:copr.fedorainfracloud.org:ublue-os:staging install \
-	-x bluefin-logos \
 	jetbrains-mono-fonts-all \
-	gnome-shell-extension-{search-light,gsconnect,logo-menu,caffeine} \
-	ublue-{motd,fastfetch,brew,bling,rebase-helper,setup-services} \
-	uupd \
-	bluefin-*
+	gnome-shell-extension-{search-light,gsconnect,logo-menu,caffeine}
 
-dnf -y --enablerepo copr:copr.fedorainfracloud.org:ublue-os:staging swap \
-	centos-logos bluefin-logos
 
 dnf config-manager --add-repo "https://copr.fedorainfracloud.org/coprs/che/nerd-fonts/repo/centos-stream-${MAJOR_VERSION_NUMBER}/che-nerd-fonts-centos-stream-${MAJOR_VERSION_NUMBER}.repo"
 dnf config-manager --set-disabled copr:copr.fedorainfracloud.org:che:nerd-fonts

--- a/build_scripts/20-packages.sh
+++ b/build_scripts/20-packages.sh
@@ -38,10 +38,10 @@ dnf config-manager --set-disabled "copr:copr.fedorainfracloud.org:ublue-os:packa
 dnf -y --enablerepo copr:copr.fedorainfracloud.org:ublue-os:packages install \
 	-x bluefin-logos \
 	ublue-os-just \
-  ublue-os-luks \
-  ublue-os-signing \
-  ublue-os-udev-rules \
-  ublue-os-update-services \
+	ublue-os-luks \
+	ublue-os-signing \
+	ublue-os-udev-rules \
+	ublue-os-update-services \
 	ublue-{motd,fastfetch,brew,bling,rebase-helper,setup-services} \
 	uupd \
 	bluefin-*

--- a/build_scripts/20-packages.sh
+++ b/build_scripts/20-packages.sh
@@ -28,11 +28,6 @@ dnf -y install \
 # Make sure to set them as disabled and enable them only when you are going to use their packages.
 # We do, however, leave crb and EPEL enabled by default.
 
-cp -r /usr/share/ublue-os/just /tmp/just
-# Focefully install ujust without powerstat while we don't have it on EPEL
-rpm -ivh /tmp/rpms/ublue-os-just.noarch.rpm --nodeps --force
-mv /tmp/just/* /usr/share/ublue-os/just
-
 dnf config-manager --add-repo "https://pkgs.tailscale.com/stable/centos/${MAJOR_VERSION_NUMBER}/tailscale.repo"
 dnf config-manager --set-disabled "tailscale-stable"
 dnf -y --enablerepo "tailscale-stable" install \
@@ -42,7 +37,11 @@ dnf config-manager --add-repo "https://copr.fedorainfracloud.org/coprs/ublue-os/
 dnf config-manager --set-disabled "copr:copr.fedorainfracloud.org:ublue-os:packages"
 dnf -y --enablerepo copr:copr.fedorainfracloud.org:ublue-os:packages install \
 	-x bluefin-logos \
-	ublue-os-* \
+	ublue-os-just \
+  ublue-os-luks \
+  ublue-os-signing \
+  ublue-os-udev-rules \
+  ublue-os-update-services \
 	ublue-{motd,fastfetch,brew,bling,rebase-helper,setup-services} \
 	uupd \
 	bluefin-*

--- a/build_scripts/20-packages.sh
+++ b/build_scripts/20-packages.sh
@@ -28,9 +28,6 @@ dnf -y install \
 # Make sure to set them as disabled and enable them only when you are going to use their packages.
 # We do, however, leave crb and EPEL enabled by default.
 
-# RPMS from Ublue-os config
-dnf -y install /tmp/rpms/ublue-os-{udev-rules,luks}.noarch.rpm
-
 cp -r /usr/share/ublue-os/just /tmp/just
 # Focefully install ujust without powerstat while we don't have it on EPEL
 rpm -ivh /tmp/rpms/ublue-os-just.noarch.rpm --nodeps --force
@@ -45,9 +42,14 @@ dnf config-manager --add-repo "https://copr.fedorainfracloud.org/coprs/ublue-os/
 dnf config-manager --set-disabled "copr:copr.fedorainfracloud.org:ublue-os:packages"
 dnf -y --enablerepo copr:copr.fedorainfracloud.org:ublue-os:packages install \
 	-x bluefin-logos \
+	ublue-os-* \
 	ublue-{motd,fastfetch,brew,bling,rebase-helper,setup-services} \
 	uupd \
 	bluefin-*
+
+# Upstream ublue-os-signing bug, we are using /usr/etc for the container signing and bootc gets mad at this
+cp -avf /usr/etc/. /etc
+rm -rvf /usr/etc
 
 dnf -y --enablerepo copr:copr.fedorainfracloud.org:ublue-os:packages swap \
 	centos-logos bluefin-logos

--- a/build_scripts/20-packages.sh
+++ b/build_scripts/20-packages.sh
@@ -41,26 +41,22 @@ dnf config-manager --set-disabled "tailscale-stable"
 dnf -y --enablerepo "tailscale-stable" install \
 	tailscale
 
-dnf config-manager --add-repo "https://copr.fedorainfracloud.org/coprs/ublue-os/bluefin/repo/epel-$MAJOR_VERSION_NUMBER/ublue-os-bluefin-epel-$MAJOR_VERSION_NUMBER.repo"
-dnf config-manager --set-disabled "copr:copr.fedorainfracloud.org:ublue-os:bluefin" \
-	-x bluefin-logos \
-	bluefin-*
-
-dnf -y --enablerepo copr:copr.fedorainfracloud.org:ublue-os:bluefin swap \
-	centos-logos bluefin-logos
-
 dnf config-manager --add-repo "https://copr.fedorainfracloud.org/coprs/ublue-os/packages/repo/epel-$MAJOR_VERSION_NUMBER/ublue-os-packages-epel-$MAJOR_VERSION_NUMBER.repo"
 dnf config-manager --set-disabled "copr:copr.fedorainfracloud.org:ublue-os:packages"
 dnf -y --enablerepo copr:copr.fedorainfracloud.org:ublue-os:packages install \
+	-x bluefin-logos \
 	ublue-{motd,fastfetch,brew,bling,rebase-helper,setup-services} \
-	uupd
+	uupd \
+	bluefin-*
+
+dnf -y --enablerepo copr:copr.fedorainfracloud.org:ublue-os:packages swap \
+	centos-logos bluefin-logos
 
 dnf config-manager --add-repo "https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/epel-$MAJOR_VERSION_NUMBER/ublue-os-staging-epel-$MAJOR_VERSION_NUMBER.repo"
 dnf config-manager --set-disabled "copr:copr.fedorainfracloud.org:ublue-os:staging"
 dnf -y --enablerepo copr:copr.fedorainfracloud.org:ublue-os:staging install \
 	jetbrains-mono-fonts-all \
 	gnome-shell-extension-{search-light,gsconnect,logo-menu,caffeine}
-
 
 dnf config-manager --add-repo "https://copr.fedorainfracloud.org/coprs/che/nerd-fonts/repo/centos-stream-${MAJOR_VERSION_NUMBER}/che-nerd-fonts-centos-stream-${MAJOR_VERSION_NUMBER}.repo"
 dnf config-manager --set-disabled copr:copr.fedorainfracloud.org:che:nerd-fonts

--- a/build_scripts/20-packages.sh
+++ b/build_scripts/20-packages.sh
@@ -39,7 +39,7 @@ dnf -y --enablerepo copr:copr.fedorainfracloud.org:ublue-os:packages install \
 	ublue-os-signing \
 	ublue-os-udev-rules \
 	ublue-os-update-services \
-	ublue-{motd,fastfetch,brew,bling,rebase-helper,setup-services} \
+	ublue-{motd,fastfetch,bling,rebase-helper,setup-services} \
 	uupd \
 	bluefin-*
 

--- a/build_scripts/20-packages.sh
+++ b/build_scripts/20-packages.sh
@@ -18,11 +18,8 @@ dnf -y install \
 	fzf \
 	glow \
 	wl-clipboard \
-	gum
-
-# FIXME: this will be on EPEL tomorrow (today: 20-02-2025)
-# dnf install -y --enablerepo="epel-testing" \
-	# jetbrains-mono-fonts-all
+	gum \
+	jetbrains-mono-fonts-all
 
 # Everything that depends on external repositories should be after this.
 # Make sure to set them as disabled and enable them only when you are going to use their packages.

--- a/build_scripts/40-services.sh
+++ b/build_scripts/40-services.sh
@@ -17,8 +17,6 @@ systemctl --global enable podman-auto-update.timer
 systemctl enable rpm-ostree-countme.service
 systemctl disable rpm-ostree.service
 systemctl enable dconf-update.service
-# Forcefully enable brew setup since the preset doesnt seem to work?
-systemctl enable brew-setup.service
 systemctl disable mcelog.service
 systemctl enable tailscaled.service
 systemctl enable uupd.timer

--- a/build_scripts/cleanup.sh
+++ b/build_scripts/cleanup.sh
@@ -12,13 +12,6 @@ sed -i 's@\[Desktop Entry\]@\[Desktop Entry\]\nHidden=true@g' /usr/share/applica
 # not updated, so we don't want to leave them enabled.
 dnf config-manager --set-disabled baseos-compose,appstream-compose
 
-# Signing needs to be as late as possible so that it wont be overwritten by anything, ever.
-dnf -y install /tmp/rpms/ublue-os-signing.noarch.rpm
-# ublue-os-signing incorrectly puts files under /usr/etc and bootc container lint gets mad at this.
-# FIXME: dear lord fix this upstream https://github.com/ublue-os/config/pull/311
-cp -avf /usr/etc/. /etc
-rm -rvf /usr/etc
-
 # Image-layer cleanup
 shopt -s extglob
 

--- a/build_scripts/overrides/x86_64/10-brew.sh
+++ b/build_scripts/overrides/x86_64/10-brew.sh
@@ -3,3 +3,6 @@
 set -xeuo pipefail
 
 dnf -y --enablerepo copr:copr.fedorainfracloud.org:ublue-os:staging install ublue-brew
+
+# Forcefully enable brew setup since the preset doesnt seem to work?
+systemctl enable brew-setup.service


### PR DESCRIPTION
This just splits the packages into `ublue-os/staging` and `ublue-os/packages` instead of just everything being in staging

It wont build for now tho! Needs some packages to exist on `ublue-os/bluefin` that we dont have yet.