### PR TITLE
fix(just): add if-not-exists switch to install-system-flatpaks

### DIFF
--- a/system_files/usr/share/ublue-os/just/60-custom.just
+++ b/system_files/usr/share/ublue-os/just/60-custom.just
@@ -1,6 +1,6 @@
 install-system-flatpaks:
     #!/usr/bin/env bash
-    flatpak remote-add --system flathub https://flathub.org/repo/flathub.flatpakrepo
+    flatpak remote-add --if-not-exists --system flathub https://flathub.org/repo/flathub.flatpakrepo
     xargs flatpak --system -y install --or-update < /etc/ublue-os/system-flatpaks.list
 
 bluefin-cli:


### PR DESCRIPTION
this removes the error if flathub is already set up and in the case you want all your flatpaks back after removing some of them