### PR TITLE
fix: make it so fastfetch does not return 1969 as the date on `Forged Date`

### DIFF
--- a/build_scripts/26-packages-post.sh
+++ b/build_scripts/26-packages-post.sh
@@ -5,6 +5,10 @@ set -xeuo pipefail
 # Fancy CentOS icon on the fastfetch
 sed -i "s/󰣛//g" /usr/share/ublue-os/fastfetch.jsonc
 
+# Fix 1969 date getting returned on Fastfetch (upstream issue)
+# FIXME: check if this issue is fixed upstream at some point. (28-02-2025) https://github.com/ostreedev/ostree/issues/1469
+sed -i -e "s@ls -alct /@&var/log@g" /usr/share/ublue-os/fastfetch.jsonc
+
 # Automatic wallpaper changing by month
 HARDCODED_RPM_MONTH="12"
 sed -i "/picture-uri/ s/${HARDCODED_RPM_MONTH}/$(date +%m)/" "/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override"


### PR DESCRIPTION
This just adds a sed expression that changes the directory being scanned from `/` to `/var/log`, which gets created at first boot and usually should be persistent until the machine dies

```diff
-"text": "date -d$(ls -alct / --time-style=full-iso|tail -1|awk '{print $6}') +'Forged on %b %d %G'",
+"text": "date -d$(ls -alct /var/log --time-style=full-iso|tail -1|awk '{print $6}') +'Forged on %b %d %G'",
```

![image](https://github.com/user-attachments/assets/560afb60-b960-463e-9d44-465402afcd70)


Fixes: #270 