### PR TITLE
fix: get gpg checking for vscode + ensure docker/podman sockets are enabled

### DIFF
--- a/build_scripts/build.sh
+++ b/build_scripts/build.sh
@@ -3,15 +3,13 @@
 # This file needs to exist otherwise running this in a RUN label makes it so bash strict mode doesnt work.
 # Thus leading to silent failures
 
-set -xeuo pipefail
+set -eo pipefail
 
 # Do not rely on any of these scripts existing in a specific path
 # Make the names as descriptive as possible and everything that uses dnf for package installation/removal should have `packages-` as a prefix.
 
 run_buildscripts_for() {
 	WHAT=$1
-	CUSTOM_NAME="${2:-}"
-	shift
 	shift
 	# Complex "find" expression here since there might not be any overrides
 	find "/var/tmp/build_scripts/overrides/$WHAT" -maxdepth 1 -iname "*-*.sh" -type f -print0 | sort --zero-terminated --sort=human-numeric | while IFS= read -r -d $'\0' script ; do
@@ -37,7 +35,9 @@ SCRIPTS_PATH="$(realpath "$(dirname "$0")/scripts")"
 export SCRIPTS_PATH
 export MAJOR_VERSION_NUMBER
 
-run_buildscripts_for .. base
+CUSTOM_NAME="base"
+run_buildscripts_for ..
+CUSTOM_NAME=""
 
 copy_systemfiles_for "$(arch)"
 run_buildscripts_for "$(arch)"

--- a/build_scripts/build.sh
+++ b/build_scripts/build.sh
@@ -10,9 +10,14 @@ set -euo pipefail
 
 run_buildscripts_for() {
 	WHAT=$1
+	CUSTOM_NAME=$2
+	shift
 	shift
 	# Complex "find" expression here since there might not be any overrides
-	find "/var/tmp/build_scripts/overrides/$WHAT" -iname "*-*.sh" -type f -maxdepth 1 -print0 | while IFS= read -r -d $'\0' script; do
+	find "/var/tmp/build_scripts/overrides/$WHAT" -iname "*-*.sh" -type f -maxdepth 1 -print0 | sort | while IFS= read -r -d $'\0' script; do
+		if [ "${CUSTOM_NAME}" != "" ] ; then
+			WHAT=$CUSTOM_NAME
+		fi
 		printf "::group:: ===$WHAT-%s===\n" "$(basename "$script")"
 		$script
 		printf "::endgroup::\n"
@@ -32,11 +37,7 @@ SCRIPTS_PATH="$(realpath "$(dirname "$0")/scripts")"
 export SCRIPTS_PATH
 export MAJOR_VERSION_NUMBER
 
-for script in /var/tmp/build_scripts/*-*.sh; do
-	printf "::group:: ===%s===\n" "$(basename "$script")"
-	$script
-	printf "::endgroup::\n"
-done
+run_buildscripts_for .. base
 
 copy_systemfiles_for "$(arch)"
 run_buildscripts_for "$(arch)"

--- a/build_scripts/build.sh
+++ b/build_scripts/build.sh
@@ -3,18 +3,18 @@
 # This file needs to exist otherwise running this in a RUN label makes it so bash strict mode doesnt work.
 # Thus leading to silent failures
 
-set -euo pipefail
+set -xeuo pipefail
 
 # Do not rely on any of these scripts existing in a specific path
 # Make the names as descriptive as possible and everything that uses dnf for package installation/removal should have `packages-` as a prefix.
 
 run_buildscripts_for() {
 	WHAT=$1
-	CUSTOM_NAME=$2
+	CUSTOM_NAME="${2:-}"
 	shift
 	shift
 	# Complex "find" expression here since there might not be any overrides
-	find "/var/tmp/build_scripts/overrides/$WHAT" -iname "*-*.sh" -type f -maxdepth 1 -print0 | sort | while IFS= read -r -d $'\0' script; do
+	find "/var/tmp/build_scripts/overrides/$WHAT" -maxdepth 1 -iname "*-*.sh" -type f -print0 | sort --zero-terminated --sort=human-numeric | while IFS= read -r -d $'\0' script ; do
 		if [ "${CUSTOM_NAME}" != "" ] ; then
 			WHAT=$CUSTOM_NAME
 		fi

--- a/build_scripts/overrides/dx/00-packages.sh
+++ b/build_scripts/overrides/dx/00-packages.sh
@@ -11,9 +11,10 @@ dnf install -y \
 # VSCode on the base image!
 dnf config-manager --add-repo "https://packages.microsoft.com/yumrepos/vscode"
 dnf config-manager --set-disabled packages.microsoft.com_yumrepos_vscode
-# TODO: Add the key from https://packages.microsoft.com/keys/microsoft.asc somehow
-# rpm --import https://packages.microsoft.com/keys/microsoft.asc fails for some reason.
-dnf -y --enablerepo packages.microsoft.com_yumrepos_vscode --nogpgcheck install code
+update-crypto-policies --set LEGACY
+rpm --import https://packages.microsoft.com/keys/microsoft.asc
+dnf -y --enablerepo packages.microsoft.com_yumrepos_vscode install code
+update-crypto-policies --set DEFAULT
 
 dnf config-manager --add-repo "https://download.docker.com/linux/centos/docker-ce.repo"
 dnf config-manager --set-disabled docker-ce-stable
@@ -23,5 +24,3 @@ dnf -y --enablerepo docker-ce-stable install \
 	containerd.io \
 	docker-buildx-plugin \
 	docker-compose-plugin
-
-systemctl enable docker

--- a/build_scripts/overrides/dx/20-services.sh
+++ b/build_scripts/overrides/dx/20-services.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+systemctl enable podman.socket
+systemctl enable docker.socket


### PR DESCRIPTION
Just noticed that the docker socket isnt enabled by default on `-dx`, we want that. And VSCode wasnt getting installed the right way (with gpg checking) so I just changed the policies and re-changed them to get it going, it shouldnt affect anything but its best to test this out eventually