### PR TITLE
feat: add buildah to the base image

### DIFF
--- a/build_scripts/20-packages.sh
+++ b/build_scripts/20-packages.sh
@@ -20,7 +20,8 @@ dnf -y install \
 	glow \
 	wl-clipboard \
 	gum \
-	jetbrains-mono-fonts-all
+	jetbrains-mono-fonts-all \
+	buildah
 
 # Everything that depends on external repositories should be after this.
 # Make sure to set them as disabled and enable them only when you are going to use their packages.


### PR DESCRIPTION
Just found out we dont have buildah on the image! We need it because there are a few things that dont work on `podman build` that work with `buildah bud`