### PR TITLE
chore: disable Renovate for GHA workflow container pinning

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,9 +12,10 @@
       "matchUpdateTypes": ["pin", "pinDigest"]
     },
     {
-      "automerge": true,
-      "matchManagers": ["dockerfile"],
-      "matchUpdateTypes": ["digest"]
+      "enabled": false,
+      "matchUpdateTypes": ["digest", "pinDigest", "pin"],
+      "matchDepTypes": ["container"],
+      "matchFileNames": [".github/workflows/**.yaml", ".github/workflows/**.yml"],
     },
   ]
 }


### PR DESCRIPTION
Try to disable Docker image pinning in GitHub Actions workflows.