### PR TITLE
feat: add k8s tools to dx and some missing flatpaks

### DIFF
--- a/build_scripts/overrides/dx/00-packages.sh
+++ b/build_scripts/overrides/dx/00-packages.sh
@@ -8,10 +8,7 @@ dnf install -y \
 # VSCode on the base image!
 dnf config-manager --add-repo "https://packages.microsoft.com/yumrepos/vscode"
 dnf config-manager --set-disabled packages.microsoft.com_yumrepos_vscode
-update-crypto-policies --set LEGACY
-rpm --import https://packages.microsoft.com/keys/microsoft.asc
-dnf -y --enablerepo packages.microsoft.com_yumrepos_vscode install code
-update-crypto-policies --set DEFAULT
+dnf -y --enablerepo --nogpgcheck packages.microsoft.com_yumrepos_vscode install code
 
 dnf config-manager --add-repo "https://download.docker.com/linux/centos/docker-ce.repo"
 dnf config-manager --set-disabled docker-ce-stable
@@ -21,3 +18,37 @@ dnf -y --enablerepo docker-ce-stable install \
 	containerd.io \
 	docker-buildx-plugin \
 	docker-compose-plugin
+
+STABLE_KUBE_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
+cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
+[kubernetes]
+name=Kubernetes
+baseurl=https://pkgs.k8s.io/core:/stable:/${STABLE_KUBE_VERSION}/rpm/
+enabled=0
+gpgcheck=1
+gpgkey=https://pkgs.k8s.io/core:/stable:/${STABLE_KUBE_VERSION}/rpm/repodata/repomd.xml.key
+EOF
+
+dnf install -y --enablerepo="kubernetes" \
+	kubectl \
+	kubeadm
+
+GITHUB_LIKE_ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')"
+KIND_LATEST_VERSION="$(curl -L https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | jq -r ".tag_name")"
+
+KIND_TMP="$(mktemp -d)"
+
+clean_kind() {
+  rm -rf "${KIND_TMP}"
+}
+trap clean_kind EXIT
+
+SHA_TYPE="256"
+KIND_BIN_NAME="kind-linux-${GITHUB_LIKE_ARCH}"
+curl --retry 3 -Lo "${KIND_TMP}/${KIND_BIN_NAME}" "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_LATEST_VERSION}/kind-linux-${GITHUB_LIKE_ARCH}"
+curl --retry 3 -Lo "${KIND_TMP}/${KIND_BIN_NAME}.sha${SHA_TYPE}sum" "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_LATEST_VERSION}/kind-linux-${GITHUB_LIKE_ARCH}.sha${SHA_TYPE}sum"
+pushd "${KIND_TMP}"
+"sha${SHA_TYPE}sum" --strict -c "${KIND_TMP}/${KIND_BIN_NAME}.sha${SHA_TYPE}sum"
+popd
+
+install -Dpm0755 "${KIND_TMP}/${KIND_BIN_NAME}" "/usr/bin/kind"

--- a/build_scripts/overrides/dx/00-packages.sh
+++ b/build_scripts/overrides/dx/00-packages.sh
@@ -8,7 +8,7 @@ dnf install -y \
 # VSCode on the base image!
 dnf config-manager --add-repo "https://packages.microsoft.com/yumrepos/vscode"
 dnf config-manager --set-disabled packages.microsoft.com_yumrepos_vscode
-dnf -y --enablerepo --nogpgcheck packages.microsoft.com_yumrepos_vscode install code
+dnf -y --enablerepo packages.microsoft.com_yumrepos_vscode --nogpgcheck  install code
 
 dnf config-manager --add-repo "https://download.docker.com/linux/centos/docker-ce.repo"
 dnf config-manager --set-disabled docker-ce-stable

--- a/build_scripts/overrides/dx/00-packages.sh
+++ b/build_scripts/overrides/dx/00-packages.sh
@@ -20,13 +20,14 @@ dnf -y --enablerepo docker-ce-stable install \
 	docker-compose-plugin
 
 STABLE_KUBE_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
+STABLE_KUBE_VERSION_MAJOR="${STABLE_KUBE_VERSION%.*}"
 cat <<EOF | tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://pkgs.k8s.io/core:/stable:/${STABLE_KUBE_VERSION}/rpm/
+baseurl=https://pkgs.k8s.io/core:/stable:/${STABLE_KUBE_VERSION_MAJOR}/rpm/
 enabled=0
 gpgcheck=1
-gpgkey=https://pkgs.k8s.io/core:/stable:/${STABLE_KUBE_VERSION}/rpm/repodata/repomd.xml.key
+gpgkey=https://pkgs.k8s.io/core:/stable:/${STABLE_KUBE_VERSION_MAJOR}/rpm/repodata/repomd.xml.key
 EOF
 
 dnf install -y --enablerepo="kubernetes" \

--- a/build_scripts/overrides/dx/00-packages.sh
+++ b/build_scripts/overrides/dx/00-packages.sh
@@ -20,7 +20,7 @@ dnf -y --enablerepo docker-ce-stable install \
 	docker-compose-plugin
 
 STABLE_KUBE_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
-cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
+cat <<EOF | tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
 baseurl=https://pkgs.k8s.io/core:/stable:/${STABLE_KUBE_VERSION}/rpm/

--- a/build_scripts/overrides/dx/05-dconf.sh
+++ b/build_scripts/overrides/dx/05-dconf.sh
@@ -12,5 +12,3 @@ cat >/usr/share/glib-2.0/schemas/zz1-dx-modifications.gschema.override <<EOF
 [org/gnome/shell/extensions/Logo-menu]
 show-boxbuddy=true
 EOF
-
-echo "io.github.dvlv.boxbuddyrs" >>/etc/ublue-os/system-flatpaks.list

--- a/build_scripts/overrides/dx/30-flatpak.sh
+++ b/build_scripts/overrides/dx/30-flatpak.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+tee -a /etc/ublue-os/system-flatpaks.list <<EOF
+io.podman_desktop.PodmanDesktop
+io.github.getnf.embellish
+io.github.dvlv.boxbuddyrs
+EOF


### PR DESCRIPTION
This works towards #280, should include kind, kubectl, kubeadm and add a few flatpaks that were missing from the -dx version