### PR TITLE
fix: use bind mount for in-repo content

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -152,6 +152,7 @@ jobs:
           version: ${{ env.CENTOS_VERSION }}
 
       - name: Load Image
+        if: github.event_name != 'pull_request'
         id: load
         run: |
           IMAGE=$(podman pull ${{ steps.rechunk.outputs.ref }})

--- a/Containerfile
+++ b/Containerfile
@@ -1,14 +1,13 @@
 ARG MAJOR_VERSION="${MAJOR_VERSION:-c10s}"
+ARG BASE_IMAGE_SHA="${BASE_IMAGE_SHA:-sha256-feea845d2e245b5e125181764cfbc26b6dacfb3124f9c8d6a2aaa4a3f91082ed}"
 FROM scratch as context
 
 COPY system_files /files
 COPY system_files_overrides /overrides
 COPY build_scripts /build_scripts
 
-FROM quay.io/centos-bootc/centos-bootc:$MAJOR_VERSION
-ARG MAJOR_VERSION="${MAJOR_VERSION:-stream10}"
+ARG MAJOR_VERSION="${MAJOR_VERSION:-c10s}"
 ARG BASE_IMAGE_SHA="sha256-feea845d2e245b5e125181764cfbc26b6dacfb3124f9c8d6a2aaa4a3f91082ed"
-
 #FROM quay.io/centos-bootc/centos-bootc:$MAJOR_VERSION
 FROM quay.io/centos-bootc/centos-bootc:$BASE_IMAGE_SHA
 

--- a/Containerfile
+++ b/Containerfile
@@ -1,17 +1,21 @@
-ARG MAJOR_VERSION="${MAJOR_VERSION:-stream10}"
+ARG MAJOR_VERSION="${MAJOR_VERSION:-c10s}"
+FROM scratch as context
+
+COPY system_files /files
+COPY system_files_overrides /overrides
+COPY build_scripts /build_scripts
+
 FROM quay.io/centos-bootc/centos-bootc:$MAJOR_VERSION
 
-# ARM should be handled by $(arch)
 ARG ENABLE_DX="${ENABLE_DX:-0}"
 ARG ENABLE_HWE="${ENABLE_HWE:-0}"
 ARG ENABLE_GDX="${ENABLE_GDX:-0}"
 ARG IMAGE_NAME="${IMAGE_NAME:-bluefin}"
 ARG IMAGE_VENDOR="${IMAGE_VENDOR:-ublue-os}"
 ARG MAJOR_VERSION="${MAJOR_VERSION:-lts}"
-ARG SHA_HEAD_SHORT="${SHA_HEAD_SHORT:-}"
+ARG SHA_HEAD_SHORT="${SHA_HEAD_SHORT:-deadbeef}"
 
-COPY system_files /
-COPY system_files_overrides /var/tmp/system_files_overrides
-COPY build_scripts /var/tmp/build_scripts
-
-RUN --mount=type=tmpfs,dst=/tmp /var/tmp/build_scripts/build.sh
+RUN --mount=type=tmpfs,dst=/opt \
+  --mount=type=tmpfs,dst=/tmp \
+  --mount=type=bind,from=context,source=/,target=/run/context \
+  /run/context/build_scripts/build.sh

--- a/build_scripts/15-packages-image-base.sh
+++ b/build_scripts/15-packages-image-base.sh
@@ -8,7 +8,7 @@ set -xeuo pipefail
 dnf remove -y subscription-manager
 
 # The base images take super long to update, this just updates manually for now
-dnf -y update
+dnf -y update kernel
 dnf -y install 'dnf-command(versionlock)'
 dnf versionlock add kernel kernel-devel kernel-devel-matched kernel-core kernel-modules kernel-modules-core kernel-modules-extra kernel-uki-virt
 
@@ -69,13 +69,13 @@ dnf -y install \
 	"xdg-user-dirs-gtk" \
 	"yelp-tools"
 
-# FIXME: ffmpegthumbnailer EPEL10 request: https://bugzilla.redhat.com/show_bug.cgi?id=2349096
 dnf -y install \
 	plymouth \
 	plymouth-system-theme \
 	fwupd \
 	systemd-{resolved,container,oomd} \
-	libcamera{,-{v4l2,gstreamer,tools}}
+	libcamera{,-{v4l2,gstreamer,tools}} \
+	ffmpegthumbnailer
 
 # This package adds "[systemd] Failed Units: *" to the bashrc startup
 dnf -y remove console-login-helper-messages

--- a/build_scripts/20-packages.sh
+++ b/build_scripts/20-packages.sh
@@ -65,9 +65,3 @@ dnf config-manager --add-repo "https://copr.fedorainfracloud.org/coprs/che/nerd-
 dnf config-manager --set-disabled copr:copr.fedorainfracloud.org:che:nerd-fonts
 dnf -y --enablerepo "copr:copr.fedorainfracloud.org:che:nerd-fonts" install \
 	nerd-fonts
-
-# This is required so homebrew works indefinitely.
-# Symlinking it makes it so whenever another GCC version gets released it will break if the user has updated it without-
-# the homebrew package getting updated through our builds.
-# We could get some kind of static binary for GCC but this is the cleanest and most tested alternative. This Sucks.
-dnf -y --setopt=install_weak_deps=False install gcc

--- a/build_scripts/40-services.sh
+++ b/build_scripts/40-services.sh
@@ -21,6 +21,7 @@ systemctl enable ublue-system-setup.service
 systemctl --global enable ublue-user-setup.service
 systemctl mask bootc-fetch-apply-updates.timer bootc-fetch-apply-updates.service
 systemctl enable check-sb-key.service
+systemctl enable users-cleanup-rechunk.service
 
 # Disable lastlog display on previous failed login in GDM (This makes logins slow)
 authselect enable-feature with-silent-lastlog

--- a/build_scripts/40-services.sh
+++ b/build_scripts/40-services.sh
@@ -21,7 +21,6 @@ systemctl enable ublue-system-setup.service
 systemctl --global enable ublue-user-setup.service
 systemctl mask bootc-fetch-apply-updates.timer bootc-fetch-apply-updates.service
 systemctl enable check-sb-key.service
-systemctl enable users-cleanup-rechunk.service
 
 # Disable lastlog display on previous failed login in GDM (This makes logins slow)
 authselect enable-feature with-silent-lastlog

--- a/build_scripts/cleanup.sh
+++ b/build_scripts/cleanup.sh
@@ -12,10 +12,6 @@ sed -i 's@\[Desktop Entry\]@\[Desktop Entry\]\nHidden=true@g' /usr/share/applica
 # not updated, so we don't want to leave them enabled.
 dnf config-manager --set-disabled baseos-compose,appstream-compose
 
-# Fast track for latest rpm-ostree for rechunker
-# FIXME: remove this once it drops on latest el10
-rpm -Uvh https://kojihub.stream.centos.org/kojifiles/vol/koji02/packages/rpm-ostree/2025.6/1.el10/$(arch)/rpm-ostree-{,libs-,}2025.6-1.el10.$(arch).rpm
-
 # Image-layer cleanup
 shopt -s extglob
 

--- a/build_scripts/cleanup.sh
+++ b/build_scripts/cleanup.sh
@@ -12,17 +12,21 @@ sed -i 's@\[Desktop Entry\]@\[Desktop Entry\]\nHidden=true@g' /usr/share/applica
 # not updated, so we don't want to leave them enabled.
 dnf config-manager --set-disabled baseos-compose,appstream-compose
 
+# Fast track for latest rpm-ostree for rechunker
+# FIXME: remove this once it drops on latest el10
+rpm -Uvh https://kojihub.stream.centos.org/kojifiles/vol/koji02/packages/rpm-ostree/2025.6/1.el10/$(arch)/rpm-ostree-{,libs-,}2025.6-1.el10.$(arch).rpm
+
 # Image-layer cleanup
 shopt -s extglob
 
 dnf clean all
 rm -rf /.gitkeep \
-  /var/tmp/* \
+  /var/tmp \
   /var/lib/{dnf,rhsm} \
   /var/cache/* \
   /boot
 
-mkdir -p /boot
+mkdir -p /boot /var/tmp
 
 # Remove non-empty log files so that we dont get bootc lint errors
 find /var/log -type f -exec 'bash' '-c' "[ -s {} ] && rm {}" ';'

--- a/build_scripts/overrides/x86_64/10-brew.sh
+++ b/build_scripts/overrides/x86_64/10-brew.sh
@@ -4,5 +4,11 @@ set -xeuo pipefail
 
 dnf -y --enablerepo copr:copr.fedorainfracloud.org:ublue-os:packages install ublue-brew
 
+# This is required so homebrew works indefinitely.
+# Symlinking it makes it so whenever another GCC version gets released it will break if the user has updated it without-
+# the homebrew package getting updated through our builds.
+# We could get some kind of static binary for GCC but this is the cleanest and most tested alternative. This Sucks.
+dnf -y --setopt=install_weak_deps=False install gcc
+
 # Forcefully enable brew setup since the preset doesnt seem to work?
 systemctl enable brew-setup.service


### PR DESCRIPTION
This should enable use of newer `centos-bootc` since some corruption issues wont happen anymore. I also cleaned up and added a few packages we were missing