### PR TITLE
ci: make renovate more strict

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,20 +2,5 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:best-practices",
-  ],
-
-  "rebaseWhen": "never",
-
-  "packageRules": [
-    {
-      "automerge": true,
-      "matchUpdateTypes": ["pin", "pinDigest"]
-    },
-    {
-      "enabled": false,
-      "matchUpdateTypes": ["digest", "pinDigest", "pin"],
-      "matchDepTypes": ["container"],
-      "matchFileNames": [".github/workflows/**.yaml", ".github/workflows/**.yml"],
-    },
   ]
 }


### PR DESCRIPTION
For whatever reason we had auto-updating for the pins, we should _not_ have that, and we should pin everything even if we get 1 billion PRs, I believe