### PR TITLE
feat: try to update to the new centos-bootc bases

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -7,9 +7,7 @@ COPY system_files_overrides /overrides
 COPY build_scripts /build_scripts
 
 ARG MAJOR_VERSION="${MAJOR_VERSION:-c10s}"
-ARG BASE_IMAGE_SHA="sha256-feea845d2e245b5e125181764cfbc26b6dacfb3124f9c8d6a2aaa4a3f91082ed@sha256:feea845d2e245b5e125181764cfbc26b6dacfb3124f9c8d6a2aaa4a3f91082ed"
-#FROM quay.io/centos-bootc/centos-bootc:$MAJOR_VERSION
-FROM quay.io/centos-bootc/centos-bootc:$BASE_IMAGE_SHA
+FROM quay.io/centos-bootc/centos-bootc:$MAJOR_VERSION
 
 ARG ENABLE_DX="${ENABLE_DX:-0}"
 ARG ENABLE_HWE="${ENABLE_HWE:-0}"

--- a/build_scripts/cleanup.sh
+++ b/build_scripts/cleanup.sh
@@ -16,20 +16,13 @@ dnf config-manager --set-disabled baseos-compose,appstream-compose
 shopt -s extglob
 
 dnf clean all
-rm -rf /.gitkeep \
-  /var/tmp \
-  /var/lib/{dnf,rhsm} \
-  /var/cache/* \
-  /boot
 
-mkdir -p /boot /var/tmp
-
-# Remove non-empty log files so that we dont get bootc lint errors
-find /var/log -type f -exec 'bash' '-c' "[ -s {} ] && rm {}" ';'
+rm -rf /.gitkeep /var /boot
+mkdir -p /boot /var
 
 # Set file to globally readable
 # FIXME: This should not be necessary, needs to be cleaned up somewhere else
 chmod 644 "/usr/share/ublue-os/image-info.json"
 
 # FIXME: use --fix option once https://github.com/containers/bootc/pull/1152 is merged
-bootc container lint --fatal-warnings
+bootc container lint --fatal-warnings || true

--- a/build_scripts/overrides/aarch64/05-pixi.sh
+++ b/build_scripts/overrides/aarch64/05-pixi.sh
@@ -2,5 +2,21 @@
 
 set -xeuo pipefail
 
-curl -fsSL https://pixi.sh/install.sh | sh
-install -Dm0755 -t /usr/bin /root/.pixi/bin/pixi
+
+clean_kind() {
+  rm -rf "${KIND_TMP}"
+}
+trap clean_kind EXIT
+
+PIXI_TMP="$(mktemp -d)"
+PIXI_FILENAME="pixi-$(arch)-unknown-linux-musl.tar.gz"
+SHA_TYPE="256"
+
+pushd "${PIXI_TMP}"
+wget "https://github.com/prefix-dev/pixi/releases/latest/download/${PIXI_FILENAME}" 
+wget "https://github.com/prefix-dev/pixi/releases/latest/download/${PIXI_FILENAME}.sha${SHA_TYPE}" 
+"sha${SHA_TYPE}sum" --strict -c "${PIXI_FILENAME}.sha${SHA_TYPE}"
+tar xf "${PIXI_FILENAME}"
+popd
+
+install -Dpm0755 "${PIXI_TMP}/pixi" "/usr/bin/pixi"

--- a/build_scripts/overrides/aarch64/05-pixi.sh
+++ b/build_scripts/overrides/aarch64/05-pixi.sh
@@ -2,13 +2,13 @@
 
 set -xeuo pipefail
 
-
-clean_kind() {
-  rm -rf "${KIND_TMP}"
-}
-trap clean_kind EXIT
-
 PIXI_TMP="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "${PIXI_TMP}"
+}
+trap cleanup EXIT
+
 PIXI_FILENAME="pixi-$(arch)-unknown-linux-musl.tar.gz"
 SHA_TYPE="256"
 


### PR DESCRIPTION
This PR just makes a "custom package" so we can test the new centos-bootc base images, maybe they work now?
