### PR TITLE
chore: reenable SBOMs

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -123,11 +123,12 @@ jobs:
 
       - name: Setup Syft
         id: setup-syft
-        if: false
+        if: github.event_name != 'pull_request'
         uses: anchore/sbom-action/download-syft@f325610c9f50a54015d37c8d16cb3b0e2c8f4de0 # v0
 
       - name: Generate SBOM
-        if: false
+        id: generate-sbom
+        if: github.event_name != 'pull_request'
         env:
           IMAGE: ${{ env.IMAGE_NAME }}
           DEFAULT_TAG: ${{ env.DEFAULT_TAG }}
@@ -212,7 +213,7 @@ jobs:
           COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
 
       - name: Add SBOM Attestation
-        if: false
+        if: github.event_name != 'pull_request'
         env:
           IMAGE: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
           DIGEST: ${{ steps.push.outputs.remote_image_digest }}


### PR DESCRIPTION
This was disabled during the conferences since we wanted to be able to quickly iterate.  The conferences are over, so we can enable the SBOMs again