### PR TITLE
feat: Increase lifecycle and lower churn rate with AlmaLinux 10

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -67,7 +67,7 @@ jobs:
             OUTPUT_NAME="${OUTPUT_NAME}-${FLAVOR}"
           fi
           echo "image_ref=$OUTPUT_NAME" >> "${GITHUB_OUTPUT}"
-          
+
 
       - name: Build ISO
         id: build
@@ -107,7 +107,7 @@ jobs:
         with:
           name: ${{ env.IMAGE_NAME }}-${{ env.DEFAULT_TAG }}-${{ matrix.platform }}-iso
           if-no-files-found: error
-          path: ${{ steps.build.outputs.iso-dest }}
+          path: ${{ steps.rename.outputs.output_directory }}
 
       - name: Upload to CloudFlare
         if: inputs.upload-to-cloudflare == true && github.event_name != 'pull_request'

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -26,7 +26,7 @@ on:
         description: "The version of AlmaLinux to build the image on"
         required: false
         type: string
-        default: "stream10"
+        default: "10-kitten"
     secrets:
       SIGNING_SECRET:
         description: "The private key used to sign the image"

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -198,34 +198,34 @@ jobs:
       # your project to others to consume. You will need to create a public and private key
       # using Cosign and save the private key as a repository secret in Github for this workflow
       # to consume. For more details, review the image signing section of the README.
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.8.1
-        if: github.event_name != 'pull_request'
+      # - name: Install Cosign
+      #   uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.8.1
+      #   if: github.event_name != 'pull_request'
 
-      - name: Sign Image
-        if: github.event_name != 'pull_request'
-        run: |
-          IMAGE_FULL="${{ env.IMAGE_REGISTRY }}/${IMAGE_NAME}"
-          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${IMAGE_FULL}@${{ steps.push.outputs.remote_image_digest }}
-        env:
-          TAGS: ${{ steps.push.outputs.digest }}
-          COSIGN_EXPERIMENTAL: false
-          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
+      # - name: Sign Image
+      #   if: github.event_name != 'pull_request'
+      #   run: |
+      #     IMAGE_FULL="${{ env.IMAGE_REGISTRY }}/${IMAGE_NAME}"
+      #     cosign sign -y --key env://COSIGN_PRIVATE_KEY ${IMAGE_FULL}@${{ steps.push.outputs.remote_image_digest }}
+      #   env:
+      #     TAGS: ${{ steps.push.outputs.digest }}
+      #     COSIGN_EXPERIMENTAL: false
+      #     COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
 
-      - name: Add SBOM Attestation
-        if: github.event_name != 'pull_request'
-        env:
-          IMAGE: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
-          DIGEST: ${{ steps.push.outputs.remote_image_digest }}
-          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
-          SBOM_OUTPUT: ${{ steps.generate-sbom.outputs.OUTPUT_PATH }}
-        run: |
-          cd "$(dirname "$SBOM_OUTPUT")"
-          cosign attest -y \
-            --predicate ./sbom.json \
-            --type spdxjson \
-            --key env://COSIGN_PRIVATE_KEY \
-            "${IMAGE}@${DIGEST}"
+      # - name: Add SBOM Attestation
+      #   if: github.event_name != 'pull_request'
+      #   env:
+      #     IMAGE: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
+      #     DIGEST: ${{ steps.push.outputs.remote_image_digest }}
+      #     COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
+      #     SBOM_OUTPUT: ${{ steps.generate-sbom.outputs.OUTPUT_PATH }}
+      #   run: |
+      #     cd "$(dirname "$SBOM_OUTPUT")"
+      #     cosign attest -y \
+      #       --predicate ./sbom.json \
+      #       --type spdxjson \
+      #       --key env://COSIGN_PRIVATE_KEY \
+      #       "${IMAGE}@${DIGEST}"
 
       - name: Create Job Outputs
         if: github.event_name != 'pull_request'
@@ -416,28 +416,28 @@ jobs:
 
   # Cosign throws errors when ran inside the Fedora container for one reason or another
   # so we move this to another step in order to run on Ubuntu
-  sign:
-    needs: manifest
-    if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-    steps:
-      - name: Login to GHCR
-        run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login -u ${{ github.actor }} --password-stdin ghcr.io
-          echo ${{ secrets.GITHUB_TOKEN }} | podman login -u ${{ github.actor }} --password-stdin ghcr.io
+  # sign:
+  #   needs: manifest
+  #   if: github.event_name != 'pull_request'
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     contents: read
+  #     packages: write
+  #     id-token: write
+  #   steps:
+  #     - name: Login to GHCR
+  #       run: |
+  #         echo ${{ secrets.GITHUB_TOKEN }} | docker login -u ${{ github.actor }} --password-stdin ghcr.io
+  #         echo ${{ secrets.GITHUB_TOKEN }} | podman login -u ${{ github.actor }} --password-stdin ghcr.io
 
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.8.1
+  #     - name: Install Cosign
+  #       uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.8.1
 
-      - name: Sign Manifest
-        run: |
-          cosign sign -y --key env://COSIGN_PRIVATE_KEY $IMAGE@$DIGEST
-        env:
-          DIGEST: ${{ needs.manifest.outputs.digest }}
-          IMAGE: ${{ needs.manifest.outputs.image }}
-          COSIGN_EXPERIMENTAL: false
-          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
+  #     - name: Sign Manifest
+  #       run: |
+  #         cosign sign -y --key env://COSIGN_PRIVATE_KEY $IMAGE@$DIGEST
+  #       env:
+  #         DIGEST: ${{ needs.manifest.outputs.digest }}
+  #         IMAGE: ${{ needs.manifest.outputs.image }}
+  #         COSIGN_EXPERIMENTAL: false
+  #         COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -198,34 +198,34 @@ jobs:
       # your project to others to consume. You will need to create a public and private key
       # using Cosign and save the private key as a repository secret in Github for this workflow
       # to consume. For more details, review the image signing section of the README.
-      # - name: Install Cosign
-      #   uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.8.1
-      #   if: github.event_name != 'pull_request'
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.8.1
+        if: github.event_name != 'pull_request'
 
-      # - name: Sign Image
-      #   if: github.event_name != 'pull_request'
-      #   run: |
-      #     IMAGE_FULL="${{ env.IMAGE_REGISTRY }}/${IMAGE_NAME}"
-      #     cosign sign -y --key env://COSIGN_PRIVATE_KEY ${IMAGE_FULL}@${{ steps.push.outputs.remote_image_digest }}
-      #   env:
-      #     TAGS: ${{ steps.push.outputs.digest }}
-      #     COSIGN_EXPERIMENTAL: false
-      #     COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
+      - name: Sign Image
+        if: github.event_name != 'pull_request'
+        run: |
+          IMAGE_FULL="${{ env.IMAGE_REGISTRY }}/${IMAGE_NAME}"
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${IMAGE_FULL}@${{ steps.push.outputs.remote_image_digest }}
+        env:
+          TAGS: ${{ steps.push.outputs.digest }}
+          COSIGN_EXPERIMENTAL: false
+          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
 
-      # - name: Add SBOM Attestation
-      #   if: github.event_name != 'pull_request'
-      #   env:
-      #     IMAGE: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
-      #     DIGEST: ${{ steps.push.outputs.remote_image_digest }}
-      #     COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
-      #     SBOM_OUTPUT: ${{ steps.generate-sbom.outputs.OUTPUT_PATH }}
-      #   run: |
-      #     cd "$(dirname "$SBOM_OUTPUT")"
-      #     cosign attest -y \
-      #       --predicate ./sbom.json \
-      #       --type spdxjson \
-      #       --key env://COSIGN_PRIVATE_KEY \
-      #       "${IMAGE}@${DIGEST}"
+      - name: Add SBOM Attestation
+        if: github.event_name != 'pull_request'
+        env:
+          IMAGE: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
+          DIGEST: ${{ steps.push.outputs.remote_image_digest }}
+          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
+          SBOM_OUTPUT: ${{ steps.generate-sbom.outputs.OUTPUT_PATH }}
+        run: |
+          cd "$(dirname "$SBOM_OUTPUT")"
+          cosign attest -y \
+            --predicate ./sbom.json \
+            --type spdxjson \
+            --key env://COSIGN_PRIVATE_KEY \
+            "${IMAGE}@${DIGEST}"
 
       - name: Create Job Outputs
         if: github.event_name != 'pull_request'
@@ -416,28 +416,28 @@ jobs:
 
   # Cosign throws errors when ran inside the Fedora container for one reason or another
   # so we move this to another step in order to run on Ubuntu
-  # sign:
-  #   needs: manifest
-  #   if: github.event_name != 'pull_request'
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     contents: read
-  #     packages: write
-  #     id-token: write
-  #   steps:
-  #     - name: Login to GHCR
-  #       run: |
-  #         echo ${{ secrets.GITHUB_TOKEN }} | docker login -u ${{ github.actor }} --password-stdin ghcr.io
-  #         echo ${{ secrets.GITHUB_TOKEN }} | podman login -u ${{ github.actor }} --password-stdin ghcr.io
+  sign:
+    needs: manifest
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Login to GHCR
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login -u ${{ github.actor }} --password-stdin ghcr.io
+          echo ${{ secrets.GITHUB_TOKEN }} | podman login -u ${{ github.actor }} --password-stdin ghcr.io
 
-  #     - name: Install Cosign
-  #       uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.8.1
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.8.1
 
-  #     - name: Sign Manifest
-  #       run: |
-  #         cosign sign -y --key env://COSIGN_PRIVATE_KEY $IMAGE@$DIGEST
-  #       env:
-  #         DIGEST: ${{ needs.manifest.outputs.digest }}
-  #         IMAGE: ${{ needs.manifest.outputs.image }}
-  #         COSIGN_EXPERIMENTAL: false
-  #         COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
+      - name: Sign Manifest
+        run: |
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY $IMAGE@$DIGEST
+        env:
+          DIGEST: ${{ needs.manifest.outputs.digest }}
+          IMAGE: ${{ needs.manifest.outputs.image }}
+          COSIGN_EXPERIMENTAL: false
+          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -11,7 +11,7 @@ on:
         description: "The description of the image to build"
         required: false
         type: string
-        default: "Bluefin LTS, built on CentOS Stream with bootc"
+        default: "Bluefin LTS, built on AlmaLinux with bootc"
       flavor:
         description: "The flavor of the image to build"
         required: false
@@ -22,8 +22,8 @@ on:
         required: false
         type: string
         default: "amd64,arm64"
-      centos-version:
-        description: "The version of CentOS to build the image on"
+      almalinux-version:
+        description: "The version of AlmaLinux to build the image on"
         required: false
         type: string
         default: "stream10"
@@ -37,7 +37,7 @@ env:
   IMAGE_DESC: ${{ inputs.image-desc }}
   IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}"
   DEFAULT_TAG: "lts"
-  CENTOS_VERSION: ${{ inputs.centos-version }}
+  ALMALINUX_VERSION: ${{ inputs.almalinux-version }}
   PLATFORMS: ${{ inputs.platforms }}
 
 jobs:
@@ -135,7 +135,7 @@ jobs:
           SYFT_CMD: ${{ steps.setup-syft.outputs.cmd }}
         run: |
           sudo systemctl start podman.socket
-          
+
           OUTPUT_PATH="$(mktemp -d)/sbom.json"
           export SYFT_PARALLELISM=$(($(nproc)*2))
           sudo $SYFT_CMD ${IMAGE}:${DEFAULT_TAG} -o spdx-json=${OUTPUT_PATH}
@@ -150,7 +150,7 @@ jobs:
           ref: "localhost/${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}"
           prev-ref: "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}"
           skip_compression: true
-          version: ${{ env.CENTOS_VERSION }}
+          version: ${{ env.ALMALINUX_VERSION }}
 
       - name: Load Image
         if: github.event_name != 'pull_request'
@@ -248,7 +248,7 @@ jobs:
             /tmp/outputs/digests/*.txt
 
   manifest:
-    name: Create ${{ inputs.image-name }}:${{ inputs.centos-version }} Manifest
+    name: Create ${{ inputs.image-name }}:${{ inputs.almalinux-version }} Manifest
     runs-on: ubuntu-latest
     if: always()
     needs:
@@ -308,8 +308,8 @@ jobs:
       - name: Extract numbers from input
         id: extract-numbers
         run: |
-          numbers_only=$(echo "${{ env.CENTOS_VERSION }}" | tr -cd '0-9')
-          echo "CENTOS_VERSION_NUMBER=$numbers_only" >> $GITHUB_ENV
+          numbers_only=$(echo "${{ env.ALMALINUX_VERSION }}" | tr -cd '0-9')
+          echo "ALMALINUX_VERSION_NUMBER=$numbers_only" >> $GITHUB_ENV
 
       - name: Image Metadata
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5
@@ -318,10 +318,10 @@ jobs:
           tags: |
             type=raw,value=lts
             type=raw,value=lts-{{date 'YYYYMMDD'}}
-            type=raw,value=${{ env.CENTOS_VERSION }}
-            type=raw,value=${{ env.CENTOS_VERSION }}.{{date 'YYYYMMDD'}}
-            type=raw,value=${{ env.CENTOS_VERSION_NUMBER }}
-            type=raw,value=${{ env.CENTOS_VERSION_NUMBER }}.{{date 'YYYYMMDD'}}
+            type=raw,value=${{ env.ALMALINUX_VERSION }}
+            type=raw,value=${{ env.ALMALINUX_VERSION }}.{{date 'YYYYMMDD'}}
+            type=raw,value=${{ env.ALMALINUX_VERSION_NUMBER }}
+            type=raw,value=${{ env.ALMALINUX_VERSION_NUMBER }}.{{date 'YYYYMMDD'}}
             type=ref,event=pr
           labels: |
             io.artifacthub.package.readme-url=https://raw.githubusercontent.com/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}/refs/heads/main/README.md
@@ -332,9 +332,9 @@ jobs:
             org.opencontainers.image.title=${{ env.IMAGE_NAME }}
             org.opencontainers.image.url=https://projectbluefin.io
             org.opencontainers.image.vendor=${{ github.repository_owner }}
-            org.opencontainers.image.version=${{ env.CENTOS_VERSION }}
+            org.opencontainers.image.version=${{ env.ALMALINUX_VERSION }}
             io.artifacthub.package.deprecated=false
-            io.artifacthub.package.keywords=bootc,centos,bluefin,ublue,universal-blue
+            io.artifacthub.package.keywords=bootc,almalinux,bluefin,ublue,universal-blue
             io.artifacthub.package.license=Apache-2.0
             io.artifacthub.package.logo-url=https://avatars.githubusercontent.com/u/120078124?s=200&v=4
             io.artifacthub.package.maintainers=[{\"name\":\"tulilirockz\",\"email\":\"tulilirockz@outlook.com\"},{\"name\":\"castrojo\",\"email\":\"jorge.castro@gmail.com\"}]

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-ARG MAJOR_VERSION="${MAJOR_VERSION:-c10s}"
+ARG MAJOR_VERSION="${MAJOR_VERSION:-10-kitten}"
 ARG BASE_IMAGE_SHA="${BASE_IMAGE_SHA:-sha256-feea845d2e245b5e125181764cfbc26b6dacfb3124f9c8d6a2aaa4a3f91082ed}"
 FROM scratch as context
 
@@ -6,8 +6,8 @@ COPY system_files /files
 COPY system_files_overrides /overrides
 COPY build_scripts /build_scripts
 
-ARG MAJOR_VERSION="${MAJOR_VERSION:-c10s}"
-FROM quay.io/centos-bootc/centos-bootc:$MAJOR_VERSION
+ARG MAJOR_VERSION="${MAJOR_VERSION:-10-kitten}"
+FROM quay.io/almalinuxorg/almalinux-bootc:$MAJOR_VERSION
 
 ARG ENABLE_DX="${ENABLE_DX:-0}"
 ARG ENABLE_HWE="${ENABLE_HWE:-0}"

--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,6 @@
 export repo_organization := env("GITHUB_REPOSITORY_OWNER", "ublue-os")
 export image_name := env("IMAGE_NAME", "bluefin")
-export centos_version := env("CENTOS_VERSION", "stream10")
+export almalinux_version := env("ALMALINUX_VERSION", "10-kitten")
 export default_tag := env("DEFAULT_TAG", "lts")
 export bib_image := env("BIB_IMAGE", "quay.io/centos-bootc/bootc-image-builder:latest")
 
@@ -104,10 +104,10 @@ build $target_image=image_name $tag=default_tag $dx="0" $hwe="0" $gdx="0":
     #!/usr/bin/env bash
 
     # Get Version
-    ver="${tag}-${centos_version}.$(date +%Y%m%d)"
+    ver="${tag}-${almalinux_version}.$(date +%Y%m%d)"
 
     BUILD_ARGS=()
-    BUILD_ARGS+=("--build-arg" "MAJOR_VERSION=${centos_version}")
+    BUILD_ARGS+=("--build-arg" "MAJOR_VERSION=${almalinux_version}")
     BUILD_ARGS+=("--build-arg" "IMAGE_NAME=${image_name}")
     BUILD_ARGS+=("--build-arg" "IMAGE_VENDOR=${repo_organization}")
     BUILD_ARGS+=("--build-arg" "ENABLE_DX=${dx}")
@@ -368,7 +368,7 @@ patch-iso-branding override="0" iso_path="output/bootiso/install.iso":
         --privileged \
         -v ./output:/output \
         -v ./iso_files:/iso_files \
-        quay.io/centos/centos:stream10 \
+        quay.io/almalinuxorg/almalinux:10-kitten \
         bash -c 'dnf install -y lorax && \
     	mkdir /images && cd /iso_files/product && find . | cpio -c -o | gzip -9cv > /images/product.img && cd / \
             && mkksiso --add images --volid bluefin-boot /{{ iso_path }} /output/final.iso'

--- a/Justfile
+++ b/Justfile
@@ -368,7 +368,7 @@ patch-iso-branding override="0" iso_path="output/bootiso/install.iso":
         --privileged \
         -v ./output:/output \
         -v ./iso_files:/iso_files \
-        quay.io/almalinuxorg/almalinux:10-kitten \
+        quay.io/almalinuxorg/almalinux:${almalinux_version} \
         bash -c 'dnf install -y lorax && \
     	mkdir /images && cd /iso_files/product && find . | cpio -c -o | gzip -9cv > /images/product.img && cd / \
             && mkksiso --add images --volid bluefin-boot /{{ iso_path }} /output/final.iso'

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/13d42ded3cf54250a71ad05aca7d5961)](https://app.codacy.com/gh/ublue-os/bluefin-lts/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 [![Build Image](https://github.com/ublue-os/bluefin-lts/actions/workflows/build-image.yml/badge.svg)](https://github.com/ublue-os/bluefin-lts/actions/workflows/build-image.yml)
 
-Larger, more lethal [Bluefin](https://projectbluefin.io). `bluefin:lts` is built on CentOS Stream10.
+Larger, more lethal [Bluefin](https://projectbluefin.io). `bluefin:lts` is built on AlmaLinux Kitten 10.
 
 ![image](https://github.com/user-attachments/assets/2e160934-44e6-4aee-b2b8-accb3bcf0a41)
 

--- a/build_scripts/00-workarounds.sh
+++ b/build_scripts/00-workarounds.sh
@@ -7,9 +7,9 @@ set -xeuo pipefail
 # Enable the same compose repos during our build that the centos-bootc image
 # uses during its build.  This avoids downgrading packages in the image that
 # have strict NVR requirements.
-curl --retry 3 -Lo "/etc/yum.repos.d/compose.repo" "https://gitlab.com/redhat/centos-stream/containers/bootc/-/raw/c${MAJOR_VERSION_NUMBER}s/cs.repo"
-sed -i \
-	-e "s@- (BaseOS|AppStream)@& - Compose@" \
-	-e "s@\(baseos\|appstream\)@&-compose@" \
-	/etc/yum.repos.d/compose.repo
-cat /etc/yum.repos.d/compose.repo
+# curl --retry 3 -Lo "/etc/yum.repos.d/compose.repo" "https://gitlab.com/redhat/centos-stream/containers/bootc/-/raw/c${MAJOR_VERSION_NUMBER}s/cs.repo"
+# sed -i \
+# 	-e "s@- (BaseOS|AppStream)@& - Compose@" \
+# 	-e "s@\(baseos\|appstream\)@&-compose@" \
+# 	/etc/yum.repos.d/compose.repo
+# cat /etc/yum.repos.d/compose.repo

--- a/build_scripts/00-workarounds.sh
+++ b/build_scripts/00-workarounds.sh
@@ -4,12 +4,3 @@ set -xeuo pipefail
 
 # This is a bucket list. We want to not have anything in this file at all.
 
-# Enable the same compose repos during our build that the centos-bootc image
-# uses during its build.  This avoids downgrading packages in the image that
-# have strict NVR requirements.
-# curl --retry 3 -Lo "/etc/yum.repos.d/compose.repo" "https://gitlab.com/redhat/centos-stream/containers/bootc/-/raw/c${MAJOR_VERSION_NUMBER}s/cs.repo"
-# sed -i \
-# 	-e "s@- (BaseOS|AppStream)@& - Compose@" \
-# 	-e "s@\(baseos\|appstream\)@&-compose@" \
-# 	/etc/yum.repos.d/compose.repo
-# cat /etc/yum.repos.d/compose.repo

--- a/build_scripts/15-packages-image-base.sh
+++ b/build_scripts/15-packages-image-base.sh
@@ -43,7 +43,7 @@ dnf -y install \
 	-x PackageKit-command-not-found \
 	-x gnome-software-fedora-langpacks \
 	"NetworkManager-adsl" \
-	"centos-backgrounds" \
+	"almalinux-backgrounds" \
 	"gdm" \
 	"gnome-bluetooth" \
 	"gnome-color-manager" \

--- a/build_scripts/15-packages-image-base.sh
+++ b/build_scripts/15-packages-image-base.sh
@@ -2,10 +2,7 @@
 
 set -xeuo pipefail
 
-# This is the base for a minimal GNOME system on CentOS Stream.
-
-# This thing slows down downloads A LOT for no reason
-dnf remove -y subscription-manager
+# This is the base for a minimal GNOME system on AlmaLinux.
 
 # The base images take super long to update, this just updates manually for now
 dnf -y update kernel

--- a/build_scripts/20-packages.sh
+++ b/build_scripts/20-packages.sh
@@ -52,8 +52,6 @@ dnf -y --enablerepo copr:copr.fedorainfracloud.org:ublue-os:packages install \
 cp -avf /usr/etc/. /etc
 rm -rvf /usr/etc
 
-# dnf -y --enablerepo copr:copr.fedorainfracloud.org:ublue-os:packages swap \
-# 	almalinux-logos bluefin-logos
 dnf -y remove almalinux-logos
 
 dnf config-manager --add-repo "https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/epel-${MAJOR_VERSION_NUMBER}/ublue-os-staging-epel-$MAJOR_VERSION_NUMBER.repo"

--- a/build_scripts/20-packages.sh
+++ b/build_scripts/20-packages.sh
@@ -11,6 +11,7 @@ dnf -y install \
 	gnome-disk-utility \
 	distrobox \
 	fastfetch \
+	fish \
 	fpaste \
 	gnome-shell-extension-{appindicator,dash-to-dock,blur-my-shell} \
 	just \

--- a/build_scripts/20-packages.sh
+++ b/build_scripts/20-packages.sh
@@ -33,6 +33,7 @@ dnf config-manager --set-disabled "tailscale-stable"
 dnf -y --enablerepo "tailscale-stable" install \
 	tailscale
 
+dnf -y remove plymouth-theme-spinner
 dnf config-manager --add-repo "https://copr.fedorainfracloud.org/coprs/ublue-os/packages/repo/epel-$MAJOR_VERSION_NUMBER/ublue-os-packages-epel-$MAJOR_VERSION_NUMBER.repo"
 dnf config-manager --set-disabled "copr:copr.fedorainfracloud.org:ublue-os:packages"
 dnf -y --enablerepo copr:copr.fedorainfracloud.org:ublue-os:packages install \
@@ -51,8 +52,9 @@ dnf -y --enablerepo copr:copr.fedorainfracloud.org:ublue-os:packages install \
 cp -avf /usr/etc/. /etc
 rm -rvf /usr/etc
 
-dnf -y --enablerepo copr:copr.fedorainfracloud.org:ublue-os:packages swap \
-	centos-logos bluefin-logos
+# dnf -y --enablerepo copr:copr.fedorainfracloud.org:ublue-os:packages swap \
+# 	almalinux-logos bluefin-logos
+dnf -y remove almalinux-logos
 
 dnf config-manager --add-repo "https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/epel-${MAJOR_VERSION_NUMBER}/ublue-os-staging-epel-$MAJOR_VERSION_NUMBER.repo"
 dnf config-manager --set-disabled "copr:copr.fedorainfracloud.org:ublue-os:staging"

--- a/build_scripts/90-image-info.sh
+++ b/build_scripts/90-image-info.sh
@@ -30,7 +30,7 @@ CODE_NAME="Achillobator Giganticus"
 sed -i -f - /usr/lib/os-release <<EOF
 s/^NAME=.*/NAME=\"${IMAGE_PRETTY_NAME}\"/
 s|^VERSION_CODENAME=.*|VERSION_CODENAME=\"${CODE_NAME}\"|
-s/^ID=almalinux/ID=${IMAGE_PRETTY_NAME,}\nID_LIKE=\"${IMAGE_LIKE}\"/
+s/^ID="almalinux"/ID=${IMAGE_PRETTY_NAME,}\nID_LIKE=\"${IMAGE_LIKE}\"/
 s/^VARIANT_ID=.*/VARIANT_ID=${IMAGE_NAME}/
 s/^PRETTY_NAME=.*/PRETTY_NAME=\"${IMAGE_PRETTY_NAME} (FROM $OLD_PRETTY_NAME)\"/
 s|^HOME_URL=.*|HOME_URL=\"${HOME_URL}\"|

--- a/build_scripts/90-image-info.sh
+++ b/build_scripts/90-image-info.sh
@@ -13,7 +13,7 @@ cat >$IMAGE_INFO <<EOF
   "image-flavor": "${IMAGE_FLAVOR}",
   "image-vendor": "${IMAGE_VENDOR}",
   "image-tag": "lts",
-  "centos-version": "${MAJOR_VERSION_NUMBER}"
+  "almalinux-version": "${MAJOR_VERSION_NUMBER}"
 }
 EOF
 
@@ -30,12 +30,12 @@ CODE_NAME="Achillobator Giganticus"
 sed -i -f - /usr/lib/os-release <<EOF
 s/^NAME=.*/NAME=\"${IMAGE_PRETTY_NAME}\"/
 s|^VERSION_CODENAME=.*|VERSION_CODENAME=\"${CODE_NAME}\"|
-s/^ID=centos/ID=${IMAGE_PRETTY_NAME,}\nID_LIKE=\"${IMAGE_LIKE}\"/
+s/^ID=almalinux/ID=${IMAGE_PRETTY_NAME,}\nID_LIKE=\"${IMAGE_LIKE}\"/
 s/^VARIANT_ID=.*/VARIANT_ID=${IMAGE_NAME}/
 s/^PRETTY_NAME=.*/PRETTY_NAME=\"${IMAGE_PRETTY_NAME} (FROM $OLD_PRETTY_NAME)\"/
 s|^HOME_URL=.*|HOME_URL=\"${HOME_URL}\"|
 s|^BUG_REPORT_URL=.*|BUG_REPORT_URL=\"${BUG_SUPPORT_URL}\"|
-s|^CPE_NAME=\"cpe:/o:centos:centos|CPE_NAME=\"cpe:/o:universal-blue:bluefin-lts|
+s|^CPE_NAME=\"cpe:/o:almalinux:almalinux|CPE_NAME=\"cpe:/o:universal-blue:bluefin-lts|
 
 /^REDHAT_BUGZILLA_PRODUCT=/d
 /^REDHAT_BUGZILLA_PRODUCT_VERSION=/d

--- a/build_scripts/cleanup.sh
+++ b/build_scripts/cleanup.sh
@@ -6,7 +6,7 @@ set -xeuo pipefail
 # Specifically called by build.sh
 
 # Hide Desktop Files. Hidden removes mime associations
-sed -i 's@\[Desktop Entry\]@\[Desktop Entry\]\nHidden=true@g' /usr/share/applications/fish.desktop
+# sed -i 's@\[Desktop Entry\]@\[Desktop Entry\]\nHidden=true@g' /usr/share/applications/fish.desktop
 
 # Image-layer cleanup
 shopt -s extglob

--- a/build_scripts/cleanup.sh
+++ b/build_scripts/cleanup.sh
@@ -10,7 +10,7 @@ sed -i 's@\[Desktop Entry\]@\[Desktop Entry\]\nHidden=true@g' /usr/share/applica
 
 # The compose repos we used during the build are point in time repos that are
 # not updated, so we don't want to leave them enabled.
-dnf config-manager --set-disabled baseos-compose,appstream-compose
+# dnf config-manager --set-disabled baseos-compose,appstream-compose
 
 # Image-layer cleanup
 shopt -s extglob

--- a/build_scripts/cleanup.sh
+++ b/build_scripts/cleanup.sh
@@ -8,10 +8,6 @@ set -xeuo pipefail
 # Hide Desktop Files. Hidden removes mime associations
 sed -i 's@\[Desktop Entry\]@\[Desktop Entry\]\nHidden=true@g' /usr/share/applications/fish.desktop
 
-# The compose repos we used during the build are point in time repos that are
-# not updated, so we don't want to leave them enabled.
-# dnf config-manager --set-disabled baseos-compose,appstream-compose
-
 # Image-layer cleanup
 shopt -s extglob
 

--- a/image.toml
+++ b/image.toml
@@ -1,6 +1,6 @@
 [[customizations.user]]
-name = "centos"
-password = "centos"
+name = "almalinux"
+password = "almalinux"
 groups = ["wheel"]
 
 [[customizations.filesystem]]

--- a/system_files/etc/ublue-os/rebase_helper.json
+++ b/system_files/etc/ublue-os/rebase_helper.json
@@ -1,6 +1,6 @@
 {
 	"dx-helper-enabled": true,
 	"image-base-name": "bluefin",
-	"available-tags": ["lts", "stream10"],
+	"available-tags": ["lts", "10-kitten"],
 	"image-date-separator": "-"
 }


### PR DESCRIPTION
Bluefin LTS looks super interesting for a side-project I'm working on: a desktop distribution for usage at CERN. However, I was thinking that a better "LTS" base would be AlmaLinux 10, as that would get us a 10-year lifecycle, as opposed to 5 years for CentOS Stream 10, and a much more Enterprise-friendly churn rate.

As AlmaLinux 10 is only expected to be GA in a month or so, and I wanted to start the discussion early, I took a stab at rebasing LTS on AlmaLinux Kitten 10, which is more-or-less the same as CentOS Stream 10 right now. This runs on an old laptop and a VM, but I've only done limited testing and only on x86_64 so far.