### PR TITLE
fix: use official EPEL rpm provided by fedora

### DIFF
--- a/build_scripts/15-packages-image-base.sh
+++ b/build_scripts/15-packages-image-base.sh
@@ -12,7 +12,7 @@ dnf -y update kernel
 dnf -y install 'dnf-command(versionlock)'
 dnf versionlock add kernel kernel-devel kernel-devel-matched kernel-core kernel-modules kernel-modules-core kernel-modules-extra kernel-uki-virt
 
-dnf -y install epel-release
+dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
 dnf config-manager --set-enabled crb
 
 # Multimidia codecs


### PR DESCRIPTION
Doesn't change anything in particular for us but should work just fine