### PR TITLE
fix: enable hyperscale repos during anaconda install

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -13,8 +13,9 @@ on:
     branches:
       - main
     paths:
-      - './.github/workflows/build-iso.yml'
-      - './Justfile'
+      - '.github/workflows/build-iso.yml'
+      - 'iso_files/*'
+      - 'Justfile'
 
 env:
   IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}"

--- a/iso_files/configure_iso.sh
+++ b/iso_files/configure_iso.sh
@@ -5,7 +5,7 @@ set -x
 dnf install -y centos-release-hyperscale
 dnf config-manager --set-enabled crb
 
-dnf install -y \
+dnf --enablerepo="centos-hyperscale" install -y \
   anaconda \
   anaconda-install-env-deps \
   anaconda-live


### PR DESCRIPTION
Since the rework, we need to explicitly enable the hyperscale repos as part of the ISO build scripts.