### PR TITLE
fix: permissions for image-info json file

### DIFF
--- a/build_scripts/cleanup.sh
+++ b/build_scripts/cleanup.sh
@@ -19,5 +19,9 @@ mkdir -p /var /boot
 # Make /usr/local writeable
 ln -s /var/usrlocal /usr/local
 
+# We need this else anything accessing image-info fails
+# FIXME: Figure out why this doesnt have the right permissions by default
+chmod 644 /usr/share/ublue-os/image-info.json
+
 # FIXME: use --fix option once https://github.com/containers/bootc/pull/1152 is merged
 bootc container lint --fatal-warnings || true


### PR DESCRIPTION

Fixes that annoying "permission denied" when anything access that file