### PR TITLE
fix: disable distrobox module on uupd

### DIFF
--- a/build_scripts/40-services.sh
+++ b/build_scripts/40-services.sh
@@ -2,6 +2,8 @@
 
 set -xeuo pipefail
 
+sed -i 's|uupd|& --disable-module-distrobox|' /usr/lib/systemd/system/uupd.service
+
 # Enable sleep then hibernation by DEFAULT!
 sed -i 's/#HandleLidSwitch=.*/HandleLidSwitch=suspend-then-hibernate/g' /usr/lib/systemd/logind.conf
 sed -i 's/#HandleLidSwitchDocked=.*/HandleLidSwitchDocked=suspend-then-hibernate/g' /usr/lib/systemd/logind.conf


### PR DESCRIPTION
Depends on: https://github.com/ublue-os/uupd/pull/71

This correctly generates the command line thing on my system:
```
$ sed 's|uupd|& --disable-module-distrobox|' /usr/lib/systemd/system/uupd.service

[Unit]
Description=Universal Blue Update Oneshot Service

[Service]
Type=oneshot
ExecStart=/usr/bin/uupd --disable-module-distrobox --log-level debug --json --hw-check
```