### PR TITLE
fix: use ujust update recipe from bluefin proper

### DIFF
--- a/system_files/usr/share/ublue-os/just/10-update.just
+++ b/system_files/usr/share/ublue-os/just/10-update.just
@@ -3,7 +3,31 @@
 alias upgrade := update
 
 update:
-    pkexec uupd --log-level debug
+    #!/usr/bin/bash
+    if systemctl cat -- uupd.timer &> /dev/null; then
+        SERVICE="uupd.service"
+    else
+        SERVICE="rpm-ostreed-automatic.service"
+    fi
+    if systemctl is-active --quiet "$SERVICE"; then
+        echo "automatic updates are currently running, use \`journalctl -fexu $SERVICE\` to see logs"
+        exit 1
+    fi
+    # rpm-ostree used due to bootc upgrade not supporting local layered packages
+    sudo bootc upgrade
+    # Updates system Flatpaks
+    if flatpak remotes | grep -q system; then
+        flatpak update -y
+    fi
+    # Update user Flatpaks
+    if flatpak remotes | grep -q user; then
+        flatpak update --user -y
+    fi
+    # Guard Brew if the user does not own brew/doesn't exist
+    if [[ -O /var/home/linuxbrew/.linuxbrew/bin/brew ]]; then
+        # Upgrade will run brew update if needed
+        /var/home/linuxbrew/.linuxbrew/bin/brew upgrade
+    fi
 
 alias auto-update := toggle-updates
 


### PR DESCRIPTION
We decided that uupd should be used just for system services, this just moves the interactive part to work the same way as bluefin proper, manually updating stuff

Fixes: https://github.com/ublue-os/bluefin-lts/issues/202