### PR TITLE
feat: add btrfs-progs and zram by default

### DIFF
--- a/build_scripts/20-packages.sh
+++ b/build_scripts/20-packages.sh
@@ -22,6 +22,7 @@ dnf -y install \
 	gum \
 	jetbrains-mono-fonts-all \
 	buildah \
+	btrfs-progs \
         xhost
 
 # Everything that depends on external repositories should be after this.

--- a/system_files/etc/systemd/zram-generator.conf
+++ b/system_files/etc/systemd/zram-generator.conf
@@ -1,0 +1,3 @@
+[zram0]
+zram-size = min(ram / 2, 4096)
+compression-algorithm = zstd


### PR DESCRIPTION
The hyperscale kernel supports btrfs/zram just fine, we can default to having this instead of not
Fixes: #455