### PR TITLE
fix: SBOM zstd compression

### DIFF
--- a/.github/workflows/build-gdx.yml
+++ b/.github/workflows/build-gdx.yml
@@ -21,5 +21,5 @@ jobs:
       image-name: bluefin-gdx
       flavor: gdx
       rechunk: ${{ github.event_name != 'pull_request' }}
-      sbom: false
+      sbom: ${{ github.event_name != 'pull_request' }}
       publish: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -240,9 +240,25 @@ jobs:
           SBOM_OUTPUT: ${{ steps.generate-sbom.outputs.OUTPUT_PATH }}
         run: |
           cd "$(dirname "$SBOM_OUTPUT")"
+
+          # Compress the SBOM and create the predicate
+          TYPE="urn:ublue-os:attestation:spdx+json+zstd:v1"
+          zstd -19 "./sbom.json" -o "./sbom.json.zst"
+          BASE64_SBOM_FILE="payload.b64"
+          base64 "./sbom.json.zst" | tr -d '\n' > "${BASE64_SBOM_FILE}"
+          PREDICATE_FILE="payload.json"
+          jq -n \
+            --arg compression "zstd" \
+            --arg mediaType "application/spdx+json" \
+            --rawfile payload "${BASE64_SBOM_FILE}" \
+            '{compression: $compression, mediaType: $mediaType, payload: $payload}' \
+            > "$PREDICATE_FILE"
+          rm -f "${BASE64_SBOM_FILE}"
+
+          # Create the attestation
           cosign attest -y \
-            --predicate ./sbom.json \
-            --type spdxjson \
+            --predicate ${PREDICATE_FILE} \
+            --type $TYPE \
             --key env://COSIGN_PRIVATE_KEY \
             "${IMAGE}@${DIGEST}"
 

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -257,7 +257,7 @@ jobs:
 
           # Create the attestation
           cosign attest -y \
-            --predicate ${PREDICATE_FILE} \
+            --predicate "${PREDICATE_FILE}" \
             --type $TYPE \
             --key env://COSIGN_PRIVATE_KEY \
             "${IMAGE}@${DIGEST}"


### PR DESCRIPTION
Due to size limitations of attestations, we need to compress the SBOM.  
Chose zstd since it's fast and reduces the size considerably.  

```
$ cosign download attestation \  
  --predicate-type urn:ublue-os:attestation:spdx+json+zstd:v1 \
  "ghcr.io/ublue-os/bluefin@sha256:xyz" \
  | jq -r .payload \
  | base64 -d \
  | jq -r .predicate.payload \
  | base64 -d \
  | zstd -d > ./sbom.json
```