### PR TITLE
fix: remove unneeded kernel updates

### DIFF
--- a/build_scripts/10-packages-image-base.sh
+++ b/build_scripts/10-packages-image-base.sh
@@ -11,10 +11,6 @@ dnf -y install centos-release-hyperscale-kernel
 dnf config-manager --set-disabled "centos-hyperscale,centos-hyperscale-kernel"
 dnf --enablerepo="centos-hyperscale" --enablerepo="centos-hyperscale-kernel" -y update kernel
 
-# The base images take super long to update, this just updates manually for now
-dnf -y install 'dnf-command(versionlock)'
-dnf versionlock add kernel kernel-devel kernel-devel-matched kernel-core kernel-modules kernel-modules-core kernel-modules-extra kernel-uki-virt
-
 dnf -y install "https://dl.fedoraproject.org/pub/epel/epel-release-latest-${MAJOR_VERSION_NUMBER}.noarch.rpm"
 dnf config-manager --set-enabled crb
 


### PR DESCRIPTION
The base images are updating regularly now, we don't need this do we?