### PR TITLE
fix: working vscode install GPG check

### DIFF
--- a/build_scripts/overrides/dx/00-packages.sh
+++ b/build_scripts/overrides/dx/00-packages.sh
@@ -9,6 +9,7 @@ dnf install -y \
 dnf config-manager --add-repo "https://packages.microsoft.com/yumrepos/vscode"
 dnf config-manager --set-disabled packages.microsoft.com_yumrepos_vscode
 update-crypto-policies --set LEGACY
+rpm --import https://packages.microsoft.com/keys/microsoft.asc
 dnf -y --enablerepo packages.microsoft.com_yumrepos_vscode install code
 update-crypto-policies --set DEFAULT
 

--- a/build_scripts/overrides/dx/00-packages.sh
+++ b/build_scripts/overrides/dx/00-packages.sh
@@ -8,7 +8,9 @@ dnf install -y \
 # VSCode on the base image!
 dnf config-manager --add-repo "https://packages.microsoft.com/yumrepos/vscode"
 dnf config-manager --set-disabled packages.microsoft.com_yumrepos_vscode
-dnf -y --enablerepo packages.microsoft.com_yumrepos_vscode --nogpgcheck  install code
+update-crypto-policies --set LEGACY
+dnf -y --enablerepo packages.microsoft.com_yumrepos_vscode install code
+update-crypto-policies --set DEFAULT
 
 dnf config-manager --add-repo "https://download.docker.com/linux/centos/docker-ce.repo"
 dnf config-manager --set-disabled docker-ce-stable


### PR DESCRIPTION
This patch allows for install of VSCode while still checking the GPG signatures on the packages.  Apparently Microsoft is (still!) using SHA-1 to sign packages, and that's no longer allowed by default in EL 10.  So we allow "the old ways" temporarily so we can get the package installed.

One side effect is that RPM will gladly tell you all about failed signatures when you run ``rpm -q code`` or ``rpm -qa``.  Unless there are other consequences I don't know about, that seems like a fair tradeoff for the Warm Security Blanket (pun intended) of validating the GPG signature on the package.

See https://discussion.fedoraproject.org/t/rejected-third-party-repository-keys/144806/6 for details.
