### PR TITLE
fix: update docker extension to container extension

### DIFF
--- a/system_files_overrides/dx/usr/share/ublue-os/user-setup.hooks.d/11-vscode.sh
+++ b/system_files_overrides/dx/usr/share/ublue-os/user-setup.hooks.d/11-vscode.sh
@@ -14,4 +14,4 @@ fi
 
 code --install-extension ms-vscode-remote.remote-containers
 code --install-extension ms-vscode-remote.remote-ssh
-code --install-extension ms-azuretools.vscode-docker
+code --install-extension ms-azuretools.vscode-containers


### PR DESCRIPTION
This is replaced upstream, existing users get prompted to upgrade within vscode anyway