### PR TITLE
feat: add ublue-branding-logos

### DIFF
--- a/build_scripts/20-packages.sh
+++ b/build_scripts/20-packages.sh
@@ -48,7 +48,7 @@ dnf -y --enablerepo copr:copr.fedorainfracloud.org:ublue-os:packages install \
 	ublue-os-signing \
 	ublue-os-udev-rules \
 	ublue-os-update-services \
-	ublue-{motd,fastfetch,bling,rebase-helper,setup-services,polkit-rules,brew} \
+	ublue-{motd,fastfetch,bling,rebase-helper,setup-services,polkit-rules,brew,branding-logos} \
 	uupd \
 	bluefin-*
 


### PR DESCRIPTION
See: https://github.com/ublue-os/packages/pull/478

The package is now available in copr
https://copr.fedorainfracloud.org/coprs/ublue-os/packages/build/9111385/