### PR TITLE
revert: "fix: working vscode install GPG check"

### DIFF
--- a/build_scripts/overrides/dx/00-packages.sh
+++ b/build_scripts/overrides/dx/00-packages.sh
@@ -8,10 +8,7 @@ dnf install -y \
 # VSCode on the base image!
 dnf config-manager --add-repo "https://packages.microsoft.com/yumrepos/vscode"
 dnf config-manager --set-disabled packages.microsoft.com_yumrepos_vscode
-update-crypto-policies --set LEGACY
-rpm --import https://packages.microsoft.com/keys/microsoft.asc
-dnf -y --enablerepo packages.microsoft.com_yumrepos_vscode install code
-update-crypto-policies --set DEFAULT
+dnf -y --enablerepo packages.microsoft.com_yumrepos_vscode --nogpgcheck  install code
 
 dnf config-manager --add-repo "https://download.docker.com/linux/centos/docker-ce.repo"
 dnf config-manager --set-disabled docker-ce-stable


### PR DESCRIPTION
Reverts ublue-os/bluefin-lts#495

We need to reinvestigate as there's a signature problem with our RPMs with this one (we think, trying it): https://github.com/ublue-os/bluefin-lts/issues/521