### PR TITLE
fix: move GNOME 48 backport COPR installation outside of testing block

### DIFF
--- a/build_scripts/10-packages-image-base.sh
+++ b/build_scripts/10-packages-image-base.sh
@@ -10,14 +10,15 @@ dnf -y install 'dnf-command(versionlock)'
 
 
 if [ "${ENABLE_TESTING}" == "1" ] ; then
-	# GNOME 48 backport COPR
-	dnf copr enable -y "jreilly1821/c10s-gnome-48"
-        dnf -y install glib2
 	dnf -y install centos-release-kmods-kernel
 	# Install and pin the kernel to the last minor version
 	./run/context/build_scripts/scripts/pin-kernel.sh
 	dnf config-manager --set-disabled "centos-kmods-kernel"
 fi
+
+# GNOME 48 backport COPR
+dnf copr enable -y "jreilly1821/c10s-gnome-48"
+dnf -y install glib2
 
 # This fixes a lot of skew issues on GDX because kernel-devel wont update then
 dnf versionlock add kernel kernel-devel kernel-devel-matched kernel-core kernel-modules kernel-modules-core kernel-modules-extra kernel-uki-virt


### PR DESCRIPTION
Fixes #598