### PR TITLE
Fix image tag discovery for changelogs and changelog title format

### DIFF
--- a/.github/changelogs.py
+++ b/.github/changelogs.py
@@ -363,10 +363,8 @@ def generate_changelog(
         curr_pretty = re.sub(rf"^[a-z]+.|^[0-9]+-", "", curr_pretty)
         if target == "stable-daily":
             curr_pretty = re.sub(rf"^[a-z]+-", "", curr_pretty)
-        if not fedora_version + "." in curr_pretty:
-            curr_pretty=fedora_version + "." + curr_pretty
         pretty = target.capitalize()
-        pretty += " (c" + curr_pretty + "s"
+        pretty += " (c" + fedora_version + "s." + curr_pretty
         if finish:
             pretty += ", #" + finish[:7]
         pretty += ")"

--- a/.github/changelogs.py
+++ b/.github/changelogs.py
@@ -17,7 +17,7 @@ IMAGE_MATRIX = {
 RETRIES = 3
 RETRY_WAIT = 5
 FEDORA_PATTERN = re.compile(r"\.fc\d\d")
-START_PATTERN = lambda target: re.compile(rf"{target}-\d\d\d+")
+START_PATTERN = lambda target: re.compile(rf"{target}.\d\d\d+")
 
 PATTERN_ADD = "\n| ✨ | {name} | | {version} |"
 PATTERN_CHANGE = "\n| 🔄 | {name} | {prev} | {new} |"
@@ -360,7 +360,7 @@ def generate_changelog(
         # Remove .0 from curr
         curr_pretty = re.sub(r"\.\d{1,2}$", "", curr)
         # Remove target- from curr
-        curr_pretty = re.sub(rf"^[a-z]+-|^[0-9]+-", "", curr_pretty)
+        curr_pretty = re.sub(rf"^[a-z]+.|^[0-9]+-", "", curr_pretty)
         if target == "stable-daily":
             curr_pretty = re.sub(rf"^[a-z]+-", "", curr_pretty)
         if not fedora_version + "." in curr_pretty:
@@ -375,6 +375,7 @@ def generate_changelog(
 
     changelog = CHANGELOG_FORMAT
 
+    # TODO: is this needed?
     if target == "gts":
         changelog = changelog.splitlines()
         del changelog[9]


### PR DESCRIPTION
This PR fixes the tag discovery for generating the changelogs.

Due to a change in the tag format from `{target}-{numbers}` to `{target}.{numbers}` the regex needed to be updated in order to pull in new versions.

While I was there, and from conversations in Discord, I adjusted the formatting of the version in the title to be `c{version}s.{date}` from the old `c{version}.{date}.s`.

Tested locally with `python changelog.py lts out.txt changelog.md`