### PR TITLE
fix: remove PikaBackup from system-flatpaks list

### DIFF
--- a/system_files/etc/ublue-os/system-flatpaks.list
+++ b/system_files/etc/ublue-os/system-flatpaks.list
@@ -23,7 +23,6 @@ org.gnome.NautilusPreviewer
 org.gnome.Papers
 org.gnome.TextEditor
 org.gnome.Weather
-org.gnome.World.PikaBackup
 org.gnome.baobab
 org.gnome.clocks
 org.gnome.font-viewer


### PR DESCRIPTION
Removed 'org.gnome.World.PikaBackup' from the list.

This isn't supposed to be here.