### PR TITLE
fix(glib2): pin after installation

### DIFF
--- a/build_scripts/10-packages-image-base.sh
+++ b/build_scripts/10-packages-image-base.sh
@@ -20,6 +20,9 @@ fi
 # GNOME 48 backport COPR
 dnf copr enable -y "jreilly1821/c10s-gnome"
 dnf -y install glib2
+dnf -y upgrade glib2
+# Please, dont remove this as it will break everything GNOME related
+dnf versionlock add glib2
 
 # This fixes a lot of skew issues on GDX because kernel-devel wont update then
 dnf versionlock add kernel kernel-devel kernel-devel-matched kernel-core kernel-modules kernel-modules-core kernel-modules-extra kernel-uki-virt


### PR DESCRIPTION
Should prevent issues like GDM/GTK apps not launching