### PR TITLE
chore: use /etc source for bazaar flatpak

### DIFF
--- a/build_scripts/26-packages-post.sh
+++ b/build_scripts/26-packages-post.sh
@@ -42,10 +42,7 @@ mv /usr/share/ublue-os/just/61-lts-custom.just /usr/share/ublue-os/just/60-custo
 mkdir -p "/usr/share/ublue-os"
 echo "Cloning the repository with depth 1..."
 git clone --depth 1 "https://github.com/ublue-os/bluefin.git" "/tmp/bluefin_repo"
-cp -avf "/tmp/bluefin_repo/system_files/shared/usr/share/ublue-os/bazaar" "/etc"
-
-# TODO: remove this when fedora bluefin moved to flatpak
-sed -i 's|/usr/share/ublue-os/|/run/host/etc/|g' /etc/bazaar/config.yaml
+cp -avf "/tmp/bluefin_repo/system_files/shared/etc/bazaar" "/etc"
 
 # Generate initramfs image after installing Bluefin branding because of Plymouth subpackage
 # Add resume module so that hibernation works


### PR DESCRIPTION
only merge this after https://github.com/ublue-os/bluefin/pull/3307

this copies the config from fedora bluefin from /etc that is only used by the flatpak and can only be used by the flatpak