### PR TITLE
Bring over `battery` TuneD profiles for auto switching on AC/Battery

### DIFF
--- a/system_files/etc/tuned/ppd.conf
+++ b/system_files/etc/tuned/ppd.conf
@@ -1,0 +1,15 @@
+[main]
+# The default PPD profile
+default=balanced
+battery_detection=true
+sysfs_acpi_monitor=true
+
+[profiles]
+# PPD = TuneD
+power-saver=powersave
+balanced=balanced
+performance=throughput-performance
+
+[battery]
+# PPD = TuneD
+balanced=balanced-battery


### PR DESCRIPTION
Fixes #831

allows for power profiles to be change automagically when on AC/Battery