### PR TITLE
chore: get rid of bluefin-fastfetch and faces packages

### DIFF
--- a/build_scripts/20-packages.sh
+++ b/build_scripts/20-packages.sh
@@ -59,7 +59,10 @@ dnf -y --enablerepo copr:copr.fedorainfracloud.org:ublue-os:packages install \
 	ublue-os-update-services \
 	ublue-{motd,fastfetch,bling,rebase-helper,setup-services,polkit-rules,brew} \
 	uupd \
-	bluefin-*
+	bluefin-schemas \
+	bluefin-backgrounds \
+	bluefin-cli-logos \
+	bluefin-plymouth
 
 # Upstream ublue-os-signing bug, we are using /usr/etc for the container signing and bootc gets mad at this
 # FIXME: remove this once https://github.com/ublue-os/packages/issues/245 is closed

--- a/build_scripts/90-image-info.sh
+++ b/build_scripts/90-image-info.sh
@@ -53,7 +53,8 @@ BUILD_ID="${SHA_HEAD_SHORT:-deadbeef}"
 EOF
 
 # Weekly user count for fastfetch
-curl --retry 3 https://raw.githubusercontent.com/ublue-os/countme/main/badge-endpoints/bluefin-lts.json | jq -r ".message" > /usr/share/ublue-os/fastfetch-user-count
+# FIXME: change this back to -lts once CentOS fixed their countme
+curl --retry 3 https://raw.githubusercontent.com/ublue-os/countme/main/badge-endpoints/bluefin.json | jq -r ".message" > /usr/share/ublue-os/fastfetch-user-count
 
 # bazaar weekly downloads used for fastfetch
 curl -X 'GET' \

--- a/image-versions.yaml
+++ b/image-versions.yaml
@@ -6,4 +6,4 @@ images:
   - name: common
     image: ghcr.io/projectbluefin/common
     tag: latest
-    digest: sha256:9598ceaac5fcd17b7bacf0c0ef909444314c7624f8aded10bfcfde69aa529c82
+    digest: sha256:5ad432a4da41a82fe07907b96cd8ad35e1b455b66d56c32002445e513ec8aa07

--- a/system_files/etc/ublue-os/fastfetch.json
+++ b/system_files/etc/ublue-os/fastfetch.json
@@ -1,4 +1,0 @@
-{
-	"logo-directory": "/usr/share/ublue-os/bluefin-logos/symbols",
-	"shuffle-logo": true	
-}


### PR DESCRIPTION
the json config gets centralized in common, we have this because fastfetch lacks a shuffle logo feature