### PR TITLE
chore: move `ublue-privileged-setup` invocation to `/usr/bin` instead of `/usr/libexec`

### DIFF
--- a/system_files/usr/share/ublue-os/user-setup.hooks.d/99-privileged.sh
+++ b/system_files/usr/share/ublue-os/user-setup.hooks.d/99-privileged.sh
@@ -4,4 +4,4 @@ set -euo pipefail
 
 echo "Running all privileged units"
 
-pkexec /usr/libexec/ublue-privileged-setup
+pkexec /usr/bin/ublue-privileged-setup


### PR DESCRIPTION
Goes with https://github.com/projectbluefin/common/pull/49
LTS equivalent of https://github.com/ublue-os/bluefin/pull/3846

This is meant to standardize closer to the FHS standard instead of
relying on a fedora-specific extension
