### PR TITLE
fix: bootc container lint

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -42,3 +42,5 @@ RUN --mount=type=tmpfs,dst=/opt \
 # Makes `/opt` writeable by default
 # Needs to be here to make the main image build strict (no /opt there)
 RUN rm -rf /opt && ln -s /var/opt /opt 
+
+RUN bootc container lint --no-truncate

--- a/Containerfile
+++ b/Containerfile
@@ -43,4 +43,4 @@ RUN --mount=type=tmpfs,dst=/opt \
 # Needs to be here to make the main image build strict (no /opt there)
 RUN rm -rf /opt && ln -s /var/opt /opt 
 
-RUN bootc container lint --no-truncate --fatal-warnings 
+RUN find /var -mindepth 1 -delete && bootc container lint --no-truncate --fatal-warnings 

--- a/Containerfile
+++ b/Containerfile
@@ -43,4 +43,4 @@ RUN --mount=type=tmpfs,dst=/opt \
 # Needs to be here to make the main image build strict (no /opt there)
 RUN rm -rf /opt && ln -s /var/opt /opt 
 
-RUN bootc container lint --no-truncate
+RUN bootc container lint --no-truncate --fatal-warnings 

--- a/build_scripts/cleanup.sh
+++ b/build_scripts/cleanup.sh
@@ -30,6 +30,3 @@ ln -s /var/usrlocal /usr/local
 # We need this else anything accessing image-info fails
 # FIXME: Figure out why this doesnt have the right permissions by default
 chmod 644 /usr/share/ublue-os/image-info.json
-
-# FIXME: use --fix option once https://github.com/containers/bootc/pull/1152 is merged
-bootc container lint --fatal-warnings || true


### PR DESCRIPTION
this treats warnings as fatal -> make them fail
and then we always make them succeed anyway?

We have so many warnings that we need the full output