### PR TITLE
fix: install libgda for Copyous extention

### DIFF
--- a/build_scripts/20-packages.sh
+++ b/build_scripts/20-packages.sh
@@ -22,6 +22,7 @@ dnf -y install \
 	hplip \
 	jetbrains-mono-fonts-all \
 	just \
+	libgda-sqlite \
 	NetworkManager-openconnect-gnome \
 	NetworkManager-openvpn-gnome \
 	nss-mdns \


### PR DESCRIPTION
Fixes #929

Adding `libgda-sqlite` so Copyous works