### PR TITLE
fix(gdx): nvidia-specific override for kms-modifiers

### DIFF
--- a/build_scripts/overrides/gdx/40-overrides.sh
+++ b/build_scripts/overrides/gdx/40-overrides.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+sed -i "/experimental-features/ s/\]/, 'kms-modifiers'&/" /usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+echo "Compiling gschema to include bluefin setting overrides"
+glib-compile-schemas /usr/share/glib-2.0/schemas


### PR DESCRIPTION
We've been doing this on Fedora bluefin for a while, should fix an unfiled parity issue.

Sister PR: https://github.com/projectbluefin/common/pull/124
