### PR TITLE
chore(pull): move to merge instead of rebase

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -2,13 +2,15 @@ version: "1"
 rules:
   - base: lts
     upstream: main
-    mergeMethod: rebase
+    mergeMethod: merge
     mergeUnstable: false
     reviewers:
       - castrojo
       - tulilirockz
+      - hanthor
     conflictReviewers:
       - castrojo
       - tulilirockz
+      - hanthor
 label: "promotion"
 conflictLabel: "promotion-conflict"


### PR DESCRIPTION
We found out that this is fine, coreOS people do this as well
