### PR TITLE
fix: remove merging from the Pull config

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -2,8 +2,6 @@ version: "1"
 rules:
   - base: lts
     upstream: main
-    mergeMethod: merge
-    mergeUnstable: false
     reviewers:
       - castrojo
       - tulilirockz


### PR DESCRIPTION
Removed merge method and unstable merge settings. This should mean that the Pull app will just create open PRs to be merged manually

Fixes https://github.com/projectbluefin/common/issues/132