### PR TITLE
fix(image-info): include centos version as a key

### DIFF
--- a/build_scripts/scripts/image-info-set
+++ b/build_scripts/scripts/image-info-set
@@ -16,7 +16,8 @@ ANNOYING_JQ_WORKAROUND=$(mktemp)
 jq -f /dev/stdin "${IMAGE_INFO}" >"${ANNOYING_JQ_WORKAROUND}" <<EOF
 ."image-name" = "${IMAGE_NAME}" | \
 ."image-flavor" = "${FLAVOR}" | \
-."image-ref" = "${IMAGE_REF}"
+."image-ref" = "${IMAGE_REF}" | \
+."centos-version" = "${MAJOR_VERSION_NUMBER}"
 EOF
 
 mv "${ANNOYING_JQ_WORKAROUND}" "${IMAGE_INFO}"


### PR DESCRIPTION

Useful for new rebase helper

Related: https://github.com/projectbluefin/common/issues/120
