### PR TITLE
fix(image-info): set 0644 permissions for image-info file so that unprivileged users can read it

### DIFF
--- a/build_scripts/90-image-info.sh
+++ b/build_scripts/90-image-info.sh
@@ -10,7 +10,7 @@ if [ "${ENABLE_HWE}" == "1" ] ; then
 IMAGE_TAG="${IMAGE_TAG}-hwe"
 fi
 
-cat >$IMAGE_INFO <<EOF
+tee "$IMAGE_INFO" <<EOF
 {
   "image-name": "${IMAGE_NAME}",
   "image-ref": "${IMAGE_REF}",
@@ -20,8 +20,8 @@ cat >$IMAGE_INFO <<EOF
   "centos-version": "${MAJOR_VERSION_NUMBER}"
 }
 EOF
+chmod 0644 "${IMAGE_INFO}"
 
-OLD_PRETTY_NAME="$(sh -c '. /usr/lib/os-release ; echo $NAME $VERSION')"
 IMAGE_PRETTY_NAME="Bluefin LTS"
 HOME_URL="https://projectbluefin.io"
 DOCUMENTATION_URL="https://docs.projectbluefin.io"

--- a/build_scripts/cleanup.sh
+++ b/build_scripts/cleanup.sh
@@ -19,5 +19,7 @@ mkdir -p /var /boot
 # Make /usr/local writeable
 ln -s /var/usrlocal /usr/local
 
+chmod 644 /usr/share/ublue-os/image-info.json
+
 # FIXME: use --fix option once https://github.com/containers/bootc/pull/1152 is merged
 bootc container lint --fatal-warnings || true

--- a/build_scripts/scripts/image-info-set
+++ b/build_scripts/scripts/image-info-set
@@ -19,6 +19,6 @@ jq -f /dev/stdin "${IMAGE_INFO}" >"${ANNOYING_JQ_WORKAROUND}" <<EOF
 ."image-ref" = "${IMAGE_REF}"
 EOF
 
-mv "${ANNOYING_JQ_WORKAROUND}" "${IMAGE_INFO}"
+install -Dpm0644 "${ANNOYING_JQ_WORKAROUND}" "${IMAGE_INFO}"
 cat "${IMAGE_INFO}"
 


### PR DESCRIPTION
Fixes: https://github.com/ublue-os/bluefin-lts/issues/1024
