### PR TITLE
fix: include pcsc-lite for passkey support on initramfs

### DIFF
--- a/build_scripts/20-packages.sh
+++ b/build_scripts/20-packages.sh
@@ -29,6 +29,7 @@ dnf -y install \
 	nss-mdns \
 	ntfs-3g \
 	papers-thumbnailer \
+	pcsc-lite \
 	powertop \
 	rclone \
 	restic \


### PR DESCRIPTION
Fixes all the builds that are blowing up right now
