### PR TITLE
fix: don't pull in centos-logos on downstream images

### DIFF
--- a/build_scripts/overrides/base/10-packages-image-base.sh
+++ b/build_scripts/overrides/base/10-packages-image-base.sh
@@ -94,4 +94,8 @@ dnf -y install \
 dnf -y remove console-login-helper-messages
 
 # We need to remove centos-logos before applying bluefin's logos and after installing this package. Do not remove this!
-rpm --erase --nodeps centos-logos 
+rpm --erase --nodeps centos-logos
+# HACK: There currently is no generic-logos equivalent like on Fedora
+# We need this so packages like anaconda don't replace our logos by pulling in centos-logos again
+dnf -y install https://kojipkgs.fedoraproject.org//packages/generic-logos/18.0.0/26.fc43/noarch/generic-logos-18.0.0-26.fc43.noarch.rpm
+rpm --erase --nodeps --nodb generic-logos


### PR DESCRIPTION
Not having *-logos leads to package conflicts or completely replace
them if used in downstream images if a single package like anaconda
requires them.

To comply with the licensing of the centos-logos we have to swap it out
for the generic-logos.

Related: https://github.com/ublue-os/aurora/pull/1657 and https://github.com/ublue-os/bluefin/pull/4072

fixes: https://github.com/projectbluefin/iso/issues/21