### PR TITLE
fix: use upstream xdg-terminal-exec instead of hack

### DIFF
--- a/build_scripts/20-packages.sh
+++ b/build_scripts/20-packages.sh
@@ -37,6 +37,7 @@ dnf -y install \
 	tuned-ppd \
 	wireguard-tools \
 	wl-clipboard \
+	xdg-terminal-exec \
 	xhost
 rm -rf /usr/share/doc/just
 


### PR DESCRIPTION
Lets us rely on an upstream instead of implementing a hack script :)

Followup for https://github.com/projectbluefin/common/pull/191

Sister PR for https://github.com/ublue-os/bluefin/pull/4114
