### PR TITLE
feat: add ibus-chewing for parity and better i18n

### DIFF
--- a/build_scripts/20-packages.sh
+++ b/build_scripts/20-packages.sh
@@ -23,6 +23,7 @@ dnf -y install \
 	gnome-disk-utility \
 	gum \
 	hplip \
+	ibus-chewing \
 	jetbrains-mono-fonts-all \
 	just \
 	libgda-sqlite \


### PR DESCRIPTION
Bluefin Stable uses ibus-chewing as the default input method for the zh_TW locale, and the package is available in EPEL10. Including it in the Bluefin LTS image brings parity between Stable and LTS.

When installing Bluefin LTS from an older ISO (September 2025) with Chinese (Taiwan) selected, the installer configures Chewing in GNOME, matching Stable behavior. Since ibus-chewing is not included in the LTS image, this results in a non-functional input method that must be removed manually.

Adding ibus-chewing to Bluefin LTS fixes this inconsistency and improves the default Traditional Chinese typing experience.