### PR TITLE
fix(gdx): disable arm64 builds and fix nvidia failure

### DIFF
--- a/.github/workflows/build-dx-hwe.yml
+++ b/.github/workflows/build-dx-hwe.yml
@@ -30,6 +30,7 @@ jobs:
     with:
       image-name: bluefin-dx
       flavor: dx
+      platforms: amd64
       rechunk: ${{ github.event_name != 'pull_request' }}
       sbom: ${{ github.event_name != 'pull_request' }}
       publish: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build-dx.yml
+++ b/.github/workflows/build-dx.yml
@@ -26,6 +26,7 @@ jobs:
     with:
       image-name: bluefin-dx
       flavor: dx
+      platforms: amd64
       rechunk: ${{ github.event_name != 'pull_request' }}
       sbom: ${{ github.event_name != 'pull_request' }}
       publish: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build-gdx.yml
+++ b/.github/workflows/build-gdx.yml
@@ -26,6 +26,7 @@ jobs:
     with:
       image-name: bluefin-gdx
       flavor: gdx
+      platforms: amd64
       rechunk: ${{ github.event_name != 'pull_request' }}
       sbom: ${{ github.event_name != 'pull_request' }}
       publish: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build-regular-hwe.yml
+++ b/.github/workflows/build-regular-hwe.yml
@@ -29,6 +29,7 @@ jobs:
       id-token: write
     with:
       image-name: bluefin
+      platforms: amd64
       rechunk: ${{ github.event_name != 'pull_request' }}
       sbom: ${{ github.event_name != 'pull_request' }}
       publish: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build-regular.yml
+++ b/.github/workflows/build-regular.yml
@@ -25,6 +25,7 @@ jobs:
     secrets: inherit
     with:
       image-name: bluefin
+      platforms: amd64
       rechunk: ${{ github.event_name != 'pull_request' }}
       sbom: ${{ github.event_name != 'pull_request' }}
       publish: ${{ github.event_name != 'pull_request' }}

--- a/build_scripts/overrides/gdx/20-nvidia.sh
+++ b/build_scripts/overrides/gdx/20-nvidia.sh
@@ -31,7 +31,7 @@ dnf config-manager --set-enabled "nvidia-container-toolkit"
 # Get the kmod-nvidia version to ensure driver packages match
 KMOD_VERSION="$(rpm -q --queryformat '%{VERSION}' kmod-nvidia)"
 # Determine the expected package version format (epoch:version-release)
-NVIDIA_PKG_VERSION="3:${KMOD_VERSION}-1.fc${FEDORA_VERSION}"
+NVIDIA_PKG_VERSION="3:${KMOD_VERSION}"
 
 dnf install -y --enablerepo="fedora-nvidia" \
     "libnvidia-fbc-${NVIDIA_PKG_VERSION}" \


### PR DESCRIPTION
- Allow any nvidia driver release version (repo only has -2 and -3, not -1)
- Disable arm64 builds until EPEL Multimedia provides libvvenc for aarch64