### PR TITLE
fix: re-enable arm64 builds

### DIFF
--- a/.github/workflows/build-dx-hwe.yml
+++ b/.github/workflows/build-dx-hwe.yml
@@ -32,7 +32,6 @@ jobs:
     with:
       image-name: bluefin-dx
       flavor: dx
-      platforms: amd64
       rechunk: ${{ github.event_name != 'pull_request' }}
       sbom: ${{ github.event_name != 'pull_request' }}
       publish: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build-dx-hwe.yml
+++ b/.github/workflows/build-dx-hwe.yml
@@ -32,6 +32,7 @@ jobs:
     with:
       image-name: bluefin-dx
       flavor: dx
+      kernel-pin: 6.17.12-200.fc42
       rechunk: ${{ github.event_name != 'pull_request' }}
       sbom: ${{ github.event_name != 'pull_request' }}
       publish: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build-dx.yml
+++ b/.github/workflows/build-dx.yml
@@ -28,7 +28,6 @@ jobs:
     with:
       image-name: bluefin-dx
       flavor: dx
-      platforms: amd64
       rechunk: ${{ github.event_name != 'pull_request' }}
       sbom: ${{ github.event_name != 'pull_request' }}
       publish: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build-gdx.yml
+++ b/.github/workflows/build-gdx.yml
@@ -28,6 +28,7 @@ jobs:
     with:
       image-name: bluefin-gdx
       flavor: gdx
+      kernel-pin: 6.17.12-200.fc42
       rechunk: ${{ github.event_name != 'pull_request' }}
       sbom: ${{ github.event_name != 'pull_request' }}
       publish: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build-gdx.yml
+++ b/.github/workflows/build-gdx.yml
@@ -28,7 +28,6 @@ jobs:
     with:
       image-name: bluefin-gdx
       flavor: gdx
-      platforms: amd64
       rechunk: ${{ github.event_name != 'pull_request' }}
       sbom: ${{ github.event_name != 'pull_request' }}
       publish: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build-regular-hwe.yml
+++ b/.github/workflows/build-regular-hwe.yml
@@ -31,6 +31,7 @@ jobs:
       id-token: write
     with:
       image-name: bluefin
+      kernel-pin: 6.17.12-200.fc42
       rechunk: ${{ github.event_name != 'pull_request' }}
       sbom: ${{ github.event_name != 'pull_request' }}
       publish: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build-regular-hwe.yml
+++ b/.github/workflows/build-regular-hwe.yml
@@ -31,7 +31,6 @@ jobs:
       id-token: write
     with:
       image-name: bluefin
-      platforms: amd64
       rechunk: ${{ github.event_name != 'pull_request' }}
       sbom: ${{ github.event_name != 'pull_request' }}
       publish: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build-regular.yml
+++ b/.github/workflows/build-regular.yml
@@ -27,7 +27,6 @@ jobs:
     secrets: inherit
     with:
       image-name: bluefin
-      platforms: amd64
       rechunk: ${{ github.event_name != 'pull_request' }}
       sbom: ${{ github.event_name != 'pull_request' }}
       publish: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -123,6 +123,9 @@ jobs:
           sudo apt install -y \
             podman
 
+      - name: Maximize build space
+        uses: ublue-os/remove-unwanted-software@695eb75bc387dbcd9685a8e72d23439d8686cba6 # v10
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -58,6 +58,11 @@ on:
         required: false
         type: string
         default: ""
+      kernel-pin:
+        description: "The kernel version to pin (e.g. 6.17.12-200.fc42)"
+        required: false
+        type: string
+        default: ""
     secrets:
       SIGNING_SECRET:
         description: "The private key used to sign the image"
@@ -163,7 +168,7 @@ jobs:
             ENABLE_DX=1
           fi
 
-          sudo $just build "${IMAGE_NAME}" "${DEFAULT_TAG}" "${ENABLE_DX}" "${ENABLE_GDX}" "${ENABLE_HWE}"
+          sudo $just build "${IMAGE_NAME}" "${DEFAULT_TAG}" "${ENABLE_DX}" "${ENABLE_GDX}" "${ENABLE_HWE}" "${{ inputs.kernel-pin }}"
           echo "image_tag=${DEFAULT_TAG}" >> "${GITHUB_OUTPUT}"
 
       - name: Setup Syft

--- a/Justfile
+++ b/Justfile
@@ -108,7 +108,7 @@ _ensure-yq:
     fi
 
 # Build the image using the specified parameters
-build $target_image=image_name $tag=default_tag $dx="0" $gdx="0" $hwe="0": _ensure-yq
+build $target_image=image_name $tag=default_tag $dx="0" $gdx="0" $hwe="0" $kernel_pin="": _ensure-yq
     #!/usr/bin/env bash
 
     # Get Version
@@ -129,10 +129,16 @@ build $target_image=image_name $tag=default_tag $dx="0" $gdx="0" $hwe="0": _ensu
     BUILD_ARGS+=("--build-arg" "ENABLE_GDX=${gdx}")
     BUILD_ARGS+=("--build-arg" "ENABLE_HWE=${hwe}")
     # Select akmods source tag for mounted ZFS/NVIDIA images
+    ARCH=$(uname -m)
     if [[ "${hwe}" -eq "1" || "${gdx}" -eq "1" ]]; then
-        BUILD_ARGS+=("--build-arg" "AKMODS_VERSION=coreos-stable-${coreos_stable_version}")
+        AKMODS_BASE="coreos-stable-${coreos_stable_version}"
     else
-        BUILD_ARGS+=("--build-arg" "AKMODS_VERSION=centos-10")
+        AKMODS_BASE="centos-10"
+    fi
+    if [[ -n "${kernel_pin}" ]]; then
+        BUILD_ARGS+=("--build-arg" "AKMODS_VERSION=${AKMODS_BASE}-${kernel_pin}.${ARCH}")
+    else
+        BUILD_ARGS+=("--build-arg" "AKMODS_VERSION=${AKMODS_BASE}")
     fi
     if [[ -z "$(git status -s)" ]]; then
         BUILD_ARGS+=("--build-arg" "SHA_HEAD_SHORT=$(git rev-parse --short HEAD)")

--- a/build_scripts/20-packages.sh
+++ b/build_scripts/20-packages.sh
@@ -65,11 +65,9 @@ dnf -y --enablerepo "copr:copr.fedorainfracloud.org:che:nerd-fonts" install \
 # We could get some kind of static binary for GCC but this is the cleanest and most tested alternative. This Sucks.
 dnf -y --setopt=install_weak_deps=False install gcc
 
-# Downgrade to GNOME 48 from jreilly1821/c10s-gnome-48 COPR
+# Downgrade to GNOME 48 from jreilly1821/c10s-gnome COPR (enabled in 10-packages-image-base.sh)
 # This pins us to gnome-shell 48.x instead of the upstream 49.x
-dnf -y copr enable jreilly1821/c10s-gnome-48
 dnf -y swap gnome-shell gnome-shell-48.3 --allowerasing
-dnf -y copr disable jreilly1821/c10s-gnome-48
 # Versionlock GNOME components to prevent upgrades back to 49
 dnf -y install python3-dnf-plugin-versionlock
 dnf versionlock add gnome-shell gdm gnome-session-wayland-session

--- a/build_scripts/overrides/base/10-packages-image-base.sh
+++ b/build_scripts/overrides/base/10-packages-image-base.sh
@@ -12,6 +12,13 @@ dnf -y install 'dnf-command(versionlock)'
 
 /run/context/build_scripts/scripts/kernel-swap.sh
 
+# GNOME 48 backport COPR
+dnf copr enable -y "jreilly1821/c10s-gnome"
+dnf -y install glib2
+dnf -y upgrade glib2
+# Please, dont remove this as it will break everything GNOME related
+dnf versionlock add glib2
+
 # This fixes a lot of skew issues on GDX because kernel-devel wont update then
 dnf versionlock add kernel kernel-devel kernel-devel-matched kernel-core kernel-modules kernel-modules-core kernel-modules-extra kernel-uki-virt
 


### PR DESCRIPTION
Re-enables arm64 builds across all 5 workflow files. The upstream EPEL Multimedia `libvvenc` dependency issue that blocked arm64 builds has been resolved (negativo17/ffmpeg#16)

Closes #1097 