### PR TITLE
feat: publish -testing images when changes merge to main

### DIFF
--- a/.github/workflows/build-dx-hwe.yml
+++ b/.github/workflows/build-dx-hwe.yml
@@ -10,8 +10,10 @@ on:
     branches:
       - main
       - lts
-  schedule:
-    - cron: "0 1 * * TUE" # Every Tuesday at 1am UTC
+  push:
+    branches:
+      - main
+      - lts
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/build-dx.yml
+++ b/.github/workflows/build-dx.yml
@@ -10,8 +10,10 @@ on:
     branches:
       - main
       - lts
-  schedule:
-    - cron: "0 1 * * TUE" # Every Tuesday at 1am UTC
+  push:
+    branches:
+      - main
+      - lts
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/build-gdx.yml
+++ b/.github/workflows/build-gdx.yml
@@ -10,8 +10,10 @@ on:
     branches:
       - main
       - lts
-  schedule:
-    - cron: "0 1 * * TUE" # Every Tuesday at 1am UTC
+  push:
+    branches:
+      - main
+      - lts
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/build-regular-hwe.yml
+++ b/.github/workflows/build-regular-hwe.yml
@@ -10,8 +10,10 @@ on:
     branches:
       - main
       - lts
-  schedule:
-    - cron: "0 1 * * TUE" # Every Tuesday at 1am UTC
+  push:
+    branches:
+      - main
+      - lts
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/build-regular.yml
+++ b/.github/workflows/build-regular.yml
@@ -10,8 +10,10 @@ on:
     branches:
       - main
       - lts
-  schedule:
-    - cron: "0 1 * * TUE" # Every Tuesday at 1am UTC
+  push:
+    branches:
+      - main
+      - lts
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -150,7 +150,7 @@ jobs:
             ENABLE_HWE=1
           fi
 
-          if [ "${REF_NAME}" != "${PRODUCTION_BRANCH}" ] && [ "$EVENT_NAME" == "pull_request" ] || [ "${EVENT_NAME}" == "merge_group" ] ; then
+          if [ "${REF_NAME}" != "${PRODUCTION_BRANCH}" ]; then
             export TAG_SUFFIX="testing"
             export DEFAULT_TAG="${DEFAULT_TAG}-${TAG_SUFFIX}"
           fi


### PR DESCRIPTION
## Summary

Ok trying to fix this thing. This makes it so everytime something merges into main a -testing image goes out. Then when a maintainer merges the pullapp PR the LTS release gets published. 

This removes the cron because accounting for that complicates the branch logic and all that stuff. IMO a better future solution is a timed automerge of the wei/app PR instead of a cron job in the workflows.

| Trigger | Branch | Published Tag | Example |
|---------|--------|---------------|---------|
| Push (PR merge) | `main` | `lts-testing` | `ghcr.io/ublue-os/bluefin:lts-testing` |
| Push (wei/pull merge) | `lts` | `lts` (stable) | `ghcr.io/ublue-os/bluefin:lts` |
| PR opened | `main` | `lts-testing` | Build only, not published |
| PR (wei/pull) | `lts` | `lts` | Build only, not published |
| workflow_dispatch | `main` | `lts-testing` | Manual testing image |
| workflow_dispatch | `lts` | `lts` | Manual stable image |

