### PR TITLE
chore(renovate): enable automerge for additional container digests

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -38,7 +38,10 @@
       "matchUpdateTypes": ["digest"],
       "matchDepNames": [
         "quay.io/centos-bootc/centos-bootc",
-        "ghcr.io/projectbluefin/common"
+        "quay.io/centos-bootc/bootc-image-builder",
+        "ghcr.io/projectbluefin/common",
+        "ghcr.io/ublue-os/akmods-zfs",
+        "ghcr.io/ublue-os/brew"
       ]
     }
   ]


### PR DESCRIPTION
## Summary

Expands Renovate automerge coverage to include digest updates for three additional container images:

- `quay.io/centos-bootc/bootc-image-builder` - CI build tooling
- `ghcr.io/ublue-os/akmods-zfs` - ZFS kernel modules  
- `ghcr.io/ublue-os/brew` - Homebrew package manager

## Motivation

These containers receive frequent security patches and bug fixes via digest updates (SHA256 hash changes without version changes). Automerging reduces manual PR review burden while maintaining safety through:

- CI checks must pass before merge
- Branch protection rules still enforced
- Digest updates are immutable and safe

## What's Not Included

NVIDIA driver updates (`akmods-nvidia-open`) intentionally remain on manual review for hardware compatibility verification.

## Testing

- [x] `just check` passes
- [x] JSON5 syntax validated
- [x] Follows conventional commits format

## Related

This only affects digest updates (security/bug fix patches), not version upgrades. Version changes still require manual review.