### PR TITLE
feat: fix changelog generation and add HWE kernel comparison table

### DIFF
--- a/.github/changelog_config.yaml
+++ b/.github/changelog_config.yaml
@@ -44,6 +44,16 @@ templates:
   commit_format: "\n| **[{short}](https://github.com/ublue-os/bluefin-lts/commit/{githash})** | {subject} |"
   changelog_title: "{os} {tag}: {pretty}"
   handwritten_placeholder: "This is an automatically generated changelog for release `{curr}`."
+  hwe_kernel_table: |
+    ### Hardware Enablement (HWE) Kernel Comparison
+    The HWE variant provides newer kernel versions for improved hardware support.
+    
+    | Image Variant | Kernel Version |
+    | --- | --- |
+    | **Standard** (bluefin:lts) | {pkgrel:kernel} |
+    | **HWE** (bluefin:lts-hwe) | {pkgrel:kernel-hwe} |
+    
+    > **Note:** HWE images are recommended for newer hardware that requires recent kernel features.
   changelog_format: |
     {handwritten}
 
@@ -53,7 +63,6 @@ templates:
     | Name | Version |
     | --- | --- |
     | **Kernel** | {pkgrel:kernel} |
-    | **HWE Kernel** | {pkgrel:kernel-hwe} |
     | **GNOME** | {pkgrel:gnome-control-center-filesystem} |
     | **Mesa** | {pkgrel:mesa-filesystem} |
     | **Podman** | {pkgrel:podman} |
@@ -72,6 +81,8 @@ templates:
     | **CUDA** | {pkgrel:nvidia-driver-cuda} |
 
     {changes}
+
+    {hwe_kernel_table}
 
     ### How to rebase
     For current users, type the following to rebase to this version:

--- a/.github/changelogs.py
+++ b/.github/changelogs.py
@@ -23,8 +23,8 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s - %(levelname)s - %(message)s',
-    datefmt='%Y-%m-%d %H:%M:%S'
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
 )
 logger = logging.getLogger(__name__)
 
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class Config:
     """Configuration loaded from YAML file"""
+
     os_name: str
     targets: List[str]
     registry_url: str
@@ -46,7 +47,7 @@ class Config:
 def load_config(config_path: str = ".github/changelog_config.yaml") -> Config:
     """Load configuration from YAML file"""
     try:
-        with open(config_path, 'r') as f:
+        with open(config_path, "r") as f:
             data = yaml.safe_load(f)
         return Config(**data)
     except FileNotFoundError:
@@ -62,24 +63,30 @@ def load_config(config_path: str = ".github/changelog_config.yaml") -> Config:
 
 class ChangelogError(Exception):
     """Custom exception for changelog generation errors."""
+
     pass
 
 
 class ManifestFetchError(ChangelogError):
     """Exception raised when manifest fetching fails."""
+
     pass
 
 
 class TagDiscoveryError(ChangelogError):
     """Exception raised when tag discovery fails."""
+
     pass
+
 
 # Compiled regex patterns for better performance will be loaded from config
 
 # Templates and patterns will be loaded from config
 
+
 class GitHubReleaseError(ChangelogError):
     """Error related to GitHub release operations."""
+
     pass
 
 
@@ -87,10 +94,7 @@ def check_github_release_exists(tag: str) -> bool:
     """Check if a GitHub release already exists for the given tag."""
     try:
         result = subprocess.run(
-            ["gh", "release", "view", tag],
-            capture_output=True,
-            text=True,
-            timeout=30
+            ["gh", "release", "view", tag], capture_output=True, text=True, timeout=30
         )
         return result.returncode == 0
     except (subprocess.TimeoutExpired, FileNotFoundError):
@@ -102,64 +106,80 @@ def get_last_published_release_tag() -> Optional[str]:
     """Get the tag of the last published GitHub release."""
     try:
         result = subprocess.run(
-            ["gh", "release", "list", "--limit", "1", "--json", "tagName", "--jq", ".[0].tagName"],
+            [
+                "gh",
+                "release",
+                "list",
+                "--limit",
+                "1",
+                "--json",
+                "tagName",
+                "--jq",
+                ".[0].tagName",
+            ],
             capture_output=True,
             text=True,
-            timeout=30
+            timeout=30,
         )
         if result.returncode == 0 and result.stdout.strip():
             return result.stdout.strip()
         return None
     except (subprocess.TimeoutExpired, FileNotFoundError):
-        logger.warning("GitHub CLI not available or timeout - cannot get last published release")
+        logger.warning(
+            "GitHub CLI not available or timeout - cannot get last published release"
+        )
         return None
 
 
 def write_github_output(output_file: str, variables: Dict[str, str]) -> None:
     """Write variables to GitHub Actions output file."""
     try:
-        with open(output_file, 'a', encoding='utf-8') as f:
+        with open(output_file, "a", encoding="utf-8") as f:
             for key, value in variables.items():
                 f.write(f"{key}={value}\n")
-        logger.info(f"Written {len(variables)} variables to GitHub output: {output_file}")
+        logger.info(
+            f"Written {len(variables)} variables to GitHub output: {output_file}"
+        )
     except Exception as e:
         logger.error(f"Failed to write GitHub output: {e}")
 
 
 class ChangelogGenerator:
     """Main class for generating changelogs from container manifests."""
-    
+
     def __init__(self, config: Optional[Config] = None):
         """Initialize the changelog generator with configuration."""
         self.config = config or load_config()
         self._manifest_cache: Dict[str, Dict[str, Any]] = {}
-        
+
         # Compile regex patterns from config
         self.centos_pattern = re.compile(self.config.patterns["centos"])
         self.start_patterns = {
-            target: re.compile(self.config.patterns["start_pattern"].format(target=target))
+            target: re.compile(
+                self.config.patterns["start_pattern"].format(target=target)
+            )
             for target in self.config.targets
         }
-        
+
     def get_images(self, target: str) -> List[Tuple[str, str]]:
         """Generate image names and experiences for a given target."""
         images = []
         base_name = "bluefin"  # Base image name is always "bluefin"
-        
+
         for experience in self.config.image_variants:
             img = base_name
-            
+
             if "-hwe" in target:
                 images.append((img, target))
                 break
-                
+
             # Add experience suffix if it's not empty
             if experience:  # experience is like "", "-dx", "-gdx"
                 img += experience
-                
+
             images.append((img, target))  # Use target instead of experience
         return images
-    
+
     def _run_skopeo_command(self, image_url: str) -> Optional[bytes]:
         """Run skopeo inspect command with retries."""
         for attempt in range(self.config.defaults["retries"]):
@@ -169,92 +189,104 @@ class ChangelogGenerator:
                     check=True,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
-                    timeout=self.config.defaults["timeout_seconds"]
+                    timeout=self.config.defaults["timeout_seconds"],
                 )
                 return result.stdout
             except subprocess.CalledProcessError as e:
-                logger.warning(f"Failed to get {image_url} (exit code {e.returncode}), "
-                              f"retrying in {self.config.defaults['retry_wait']} seconds "
-                              f"({attempt + 1}/{self.config.defaults['retries']})")
+                logger.warning(
+                    f"Failed to get {image_url} (exit code {e.returncode}), "
+                    f"retrying in {self.config.defaults['retry_wait']} seconds "
+                    f"({attempt + 1}/{self.config.defaults['retries']})"
+                )
                 if e.stderr:
                     logger.error(f"Error: {e.stderr.decode().strip()}")
             except subprocess.TimeoutExpired:
-                logger.warning(f"Timeout getting {image_url}, "
-                              f"retrying in {self.config.defaults['retry_wait']} seconds "
-                              f"({attempt + 1}/{self.config.defaults['retries']})")
+                logger.warning(
+                    f"Timeout getting {image_url}, "
+                    f"retrying in {self.config.defaults['retry_wait']} seconds "
+                    f"({attempt + 1}/{self.config.defaults['retries']})"
+                )
             except Exception as e:
-                logger.warning(f"Unexpected error getting {image_url}: {e}, "
-                              f"retrying in {self.config.defaults['retry_wait']} seconds "
-                              f"({attempt + 1}/{self.config.defaults['retries']})")
-            
+                logger.warning(
+                    f"Unexpected error getting {image_url}: {e}, "
+                    f"retrying in {self.config.defaults['retry_wait']} seconds "
+                    f"({attempt + 1}/{self.config.defaults['retries']})"
+                )
+
             if attempt < self.config.defaults["retries"] - 1:
                 time.sleep(self.config.defaults["retry_wait"])
-        
+
         return None
-    
+
     def get_manifests(self, target: str) -> Dict[str, Any]:
         """Fetch container manifests for all image variants."""
         # Check cache first
         if target in self._manifest_cache:
             logger.info(f"Using cached manifest for {target}")
             return self._manifest_cache[target]
-            
+
         manifests = {}
         images = self.get_images(target)
-        
-        logger.info(f"Fetching manifests for {len(images)} images with target '{target}'")
+
+        logger.info(
+            f"Fetching manifests for {len(images)} images with target '{target}'"
+        )
         for i, (img, _) in enumerate(images, 1):
             logger.info(f"Getting {img}:{target} manifest ({i}/{len(images)})")
             image_url = f"docker://{self.config.registry_url}/{img}:{target}"
-            
+
             output = self._run_skopeo_command(image_url)
             if output is None:
-                logger.error(f"Failed to get {img}:{target} after {self.config.defaults['retries']} attempts")
+                logger.error(
+                    f"Failed to get {img}:{target} after {self.config.defaults['retries']} attempts"
+                )
                 continue
-                
+
             try:
                 manifests[img] = json.loads(output)
             except json.JSONDecodeError as e:
                 logger.error(f"Failed to parse JSON for {img}:{target}: {e}")
                 continue
-        
+
         if not manifests:
-            raise ManifestFetchError(f"Failed to fetch any manifests for target '{target}'")
-                
+            raise ManifestFetchError(
+                f"Failed to fetch any manifests for target '{target}'"
+            )
+
         # Cache the result
         self._manifest_cache[target] = manifests
         return manifests
 
-
-    def get_tags(self, target: str, manifests: Dict[str, Any], previous_tag: Optional[str] = None) -> Tuple[str, str]:
+    def get_tags(
+        self, target: str, manifests: Dict[str, Any], previous_tag: Optional[str] = None
+    ) -> Tuple[str, str]:
         """Extract previous and current tags from manifests."""
         if not manifests:
             raise TagDiscoveryError("No manifests provided for tag discovery")
-        
+
         # Find the current tag from manifests
         tags = set()
         first_manifest = next(iter(manifests.values()))
-        
+
         for tag in first_manifest["RepoTags"]:
             # Tags ending with .0 should not exist
             if tag.endswith(".0"):
                 continue
             if re.match(self.start_patterns[target], tag):
                 tags.add(tag)
-        
+
         # Filter tags that exist in all manifests
         for manifest in manifests.values():
             tags = {tag for tag in tags if tag in manifest["RepoTags"]}
-        
+
         sorted_tags = sorted(tags)
         if len(sorted_tags) < 1:
             raise TagDiscoveryError(
-                f"No tags found for target '{target}'. "
-                f"Available tags: {sorted_tags}"
+                f"No tags found for target '{target}'. Available tags: {sorted_tags}"
             )
-        
+
         current_tag = sorted_tags[-1]  # Latest tag
-        
+
         # Use provided previous_tag or fall back to automatic detection
         if previous_tag:
             logger.info(f"Using provided previous tag: {previous_tag}")
@@ -268,11 +300,11 @@ class ChangelogGenerator:
                 )
             prev_tag = sorted_tags[-2]  # Second latest tag
             logger.info(f"Auto-detected previous tag: {prev_tag}")
-            
+
         logger.info(f"Found {len(sorted_tags)} tags for target '{target}'")
         logger.info(f"Comparing {prev_tag} -> {current_tag}")
         return prev_tag, current_tag
-    
+
     def get_packages(self, manifests: Dict[str, Any]) -> Dict[str, Dict[str, str]]:
         """Extract package information from manifests."""
         packages = {}
@@ -282,60 +314,60 @@ class ChangelogGenerator:
                 if not rechunk_info:
                     logger.warning(f"No rechunk info found for {img}")
                     continue
-                    
+
                 packages[img] = json.loads(rechunk_info)["packages"]
                 logger.debug(f"Extracted {len(packages[img])} packages for {img}")
             except (KeyError, json.JSONDecodeError, TypeError) as e:
                 logger.error(f"Failed to get packages for {img}: {e}")
         return packages
 
-
-    def get_package_groups(self, target: str, prev: Dict[str, Any], 
-                          manifests: Dict[str, Any]) -> Tuple[List[str], Dict[str, List[str]]]:
+    def get_package_groups(
+        self, target: str, prev: Dict[str, Any], manifests: Dict[str, Any]
+    ) -> Tuple[List[str], Dict[str, List[str]]]:
         """Categorize packages into common and variant-specific groups."""
         common = set()
         others = {k: set() for k in self.config.sections.keys()}
-        
+
         npkg = self.get_packages(manifests)
         ppkg = self.get_packages(prev)
-        
+
         keys = set(npkg.keys()) | set(ppkg.keys())
         pkg = defaultdict(set)
         for k in keys:
             pkg[k] = set(npkg.get(k, {})) | set(ppkg.get(k, {}))
-        
+
         # Find common packages
         first = True
         for img, experience in self.get_images(target):
             if img not in pkg:
                 continue
-                
+
             if first:
                 common.update(pkg[img])
             else:
                 common.intersection_update(pkg[img])
             first = False
-        
+
         # Find other packages
         for t, other in others.items():
             first = True
             for img, experience in self.get_images(target):
                 if img not in pkg:
                     continue
-                    
+
                 if t == "base" and experience != "base":
                     continue
                 if t == "dx" and experience != "dx":
                     continue
-                    
+
                 if first:
                     other.update(p for p in pkg[img] if p not in common)
                 else:
                     other.intersection_update(pkg[img])
                 first = False
-        
+
         return sorted(common), {k: sorted(v) for k, v in others.items()}
-    
+
     def get_versions(self, manifests: Dict[str, Any]) -> Dict[str, str]:
         """Extract package versions from manifests."""
         versions = {}
@@ -345,16 +377,18 @@ class ChangelogGenerator:
                 versions[pkg] = re.sub(self.centos_pattern, "", version)
         return versions
 
-
-    def calculate_changes(self, pkgs: List[str], prev: Dict[str, str], 
-                         curr: Dict[str, str]) -> str:
+    def calculate_changes(
+        self, pkgs: List[str], prev: Dict[str, str], curr: Dict[str, str]
+    ) -> str:
         """Calculate package changes between versions."""
         added = []
         changed = []
         removed = []
-        
-        blacklist_ver = {curr.get(v) for v in self.config.package_blacklist if curr.get(v)}
-        
+
+        blacklist_ver = {
+            curr.get(v) for v in self.config.package_blacklist if curr.get(v)
+        }
+
         for pkg in pkgs:
             # Clean up changelog by removing mentioned packages
             if pkg in self.config.package_blacklist:
@@ -363,101 +397,131 @@ class ChangelogGenerator:
                 continue
             if pkg in prev and prev.get(pkg) in blacklist_ver:
                 continue
-                
+
             if pkg not in prev:
                 added.append(pkg)
             elif pkg not in curr:
                 removed.append(pkg)
             elif prev[pkg] != curr[pkg]:
                 changed.append(pkg)
-                
+
             # Add current versions to blacklist
             if pkg in curr:
                 blacklist_ver.add(curr[pkg])
             if pkg in prev:
                 blacklist_ver.add(prev[pkg])
-        
-        logger.info(f"Package changes: {len(added)} added, {len(changed)} changed, {len(removed)} removed")
-        
+
+        logger.info(
+            f"Package changes: {len(added)} added, {len(changed)} changed, {len(removed)} removed"
+        )
+
         output = ""
         for pkg in added:
-            output += self.config.templates["pattern_add"].format(name=pkg, version=curr[pkg])
+            output += self.config.templates["pattern_add"].format(
+                name=pkg, version=curr[pkg]
+            )
         for pkg in changed:
-            output += self.config.templates["pattern_change"].format(name=pkg, prev=prev[pkg], new=curr[pkg])
+            output += self.config.templates["pattern_change"].format(
+                name=pkg, prev=prev[pkg], new=curr[pkg]
+            )
         for pkg in removed:
-            output += self.config.templates["pattern_remove"].format(name=pkg, version=prev[pkg])
-            
+            output += self.config.templates["pattern_remove"].format(
+                name=pkg, version=prev[pkg]
+            )
+
         return output
-    
-    def get_commits(self, prev_manifests: Dict[str, Any], 
-                   manifests: Dict[str, Any], target: str, workdir: Optional[str] = None) -> str:
+
+    def get_commits(
+        self,
+        prev_manifests: Dict[str, Any],
+        manifests: Dict[str, Any],
+        target: str,
+        workdir: Optional[str] = None,
+    ) -> str:
         """Extract commit information between versions."""
         # Check if commits are enabled in configuration
         if not self.config.defaults.get("enable_commits", False):
             logger.debug("Commit extraction disabled in configuration")
             return ""
-            
+
         if not workdir:
             logger.warning("No workdir provided, skipping commit extraction")
             return ""
-            
+
         try:
             # Get commit hashes from container manifests
             start = self._get_commit_hash(prev_manifests)
             finish = self._get_commit_hash(manifests)
-            
+
             if not start or not finish:
                 logger.warning("Missing commit hashes, skipping commit extraction")
                 return ""
-            
+
             if start == finish:
                 logger.info("Same commit hash for both versions, no commits to show")
                 return ""
-            
+
             logger.info(f"Extracting commits from {start[:7]} to {finish[:7]}")
-            
+
             # Use git log with commit hashes from container manifests
             commits = subprocess.run(
-                ["git", "-C", workdir, "log", "--pretty=format:%H %h %s", 
-                 f"{start}..{finish}"],
+                [
+                    "git",
+                    "-C",
+                    workdir,
+                    "log",
+                    "--pretty=format:%H %h %s",
+                    f"{start}..{finish}",
+                ],
                 check=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                timeout=30
+                timeout=30,
             ).stdout.decode("utf-8")
-            
+
             output = ""
             commit_count = 0
             for commit in commits.split("\n"):
                 if not commit.strip():
                     continue
-                    
+
                 parts = commit.split(" ", 2)
                 if len(parts) < 3:
                     logger.debug(f"Skipping malformed commit line: {commit}")
                     continue
-                    
+
                 githash, short, subject = parts
-                
+
                 # Skip merge commits and chore commits
                 if subject.lower().startswith(("merge", "chore")):
                     continue
-                    
+
                 output += self.config.templates["commit_format"].format(
                     short=short, subject=subject, githash=githash
                 )
                 commit_count += 1
-            
+
             logger.info(f"Found {commit_count} relevant commits")
-            return self.config.templates["commits_format"].format(commits=output) if output else ""
-            
+            return (
+                self.config.templates["commits_format"].format(commits=output)
+                if output
+                else ""
+            )
+
         except subprocess.CalledProcessError as e:
             # Check if the error is due to unknown revision (commit not in repo)
             stderr_output = e.stderr.decode() if e.stderr else ""
-            if "unknown revision" in stderr_output.lower() or "bad revision" in stderr_output.lower():
-                logger.warning(f"Container commit hashes not found in git repository - trying timestamp-based approach")
+            if (
+                "unknown revision" in stderr_output.lower()
+                or "bad revision" in stderr_output.lower()
+            ):
+                logger.warning(
+                    f"Container commit hashes not found in git repository - trying timestamp-based approach"
+                )
                 logger.debug(f"Git error: {stderr_output}")
-                return self._get_commits_by_timestamp(prev_manifests, manifests, workdir)
+                return self._get_commits_by_timestamp(
+                    prev_manifests, manifests, workdir
+                )
             else:
                 logger.warning(f"Git command failed: {stderr_output}")
             return ""
@@ -467,152 +531,181 @@ class ChangelogGenerator:
         except Exception as e:
             logger.warning(f"Failed to get commits: {e}")
             return ""
-    
-    def _get_commits_by_timestamp(self, prev_manifests: Dict[str, Any], 
-                                 manifests: Dict[str, Any], workdir: str) -> str:
+
+    def _get_commits_by_timestamp(
+        self, prev_manifests: Dict[str, Any], manifests: Dict[str, Any], workdir: str
+    ) -> str:
         """Get commits using container timestamps as fallback."""
         try:
             from datetime import datetime, timedelta
-            import re
-            
+
             # Get container creation timestamps
             prev_timestamp = self._get_container_timestamp(prev_manifests)
             curr_timestamp = self._get_container_timestamp(manifests)
-            
-            logger.debug(f"Container timestamps: prev={prev_timestamp}, curr={curr_timestamp}")
-            
+
+            logger.debug(
+                f"Container timestamps: prev={prev_timestamp}, curr={curr_timestamp}"
+            )
+
             if not prev_timestamp or not curr_timestamp:
                 logger.warning("Missing container timestamps for commit correlation")
                 return ""
-            
+
             # Parse ISO 8601 timestamps
             def parse_timestamp(ts):
                 # Remove microseconds and timezone info for simpler parsing
-                ts = re.sub(r'\.\d+', '', ts)  # Remove microseconds
-                ts = ts.replace('Z', '+00:00')  # Handle Z timezone
-                return datetime.fromisoformat(ts.replace('Z', '+00:00'))
-            
+                ts = re.sub(r"\.\d+", "", ts)  # Remove microseconds
+                ts = ts.replace("Z", "+00:00")  # Handle Z timezone
+                return datetime.fromisoformat(ts)
+
             prev_dt = parse_timestamp(prev_timestamp)
             curr_dt = parse_timestamp(curr_timestamp)
-            
-            logger.info(f"Searching commits between {prev_dt.strftime('%Y-%m-%d %H:%M')} and {curr_dt.strftime('%Y-%m-%d %H:%M')}")
-            
+
+            logger.info(
+                f"Searching commits between {prev_dt.strftime('%Y-%m-%d %H:%M')} and {curr_dt.strftime('%Y-%m-%d %H:%M')}"
+            )
+
             # Add some buffer time to account for build delays
             start_time = prev_dt - timedelta(hours=2)
             end_time = curr_dt + timedelta(hours=2)
-            
-            logger.debug(f"Git time range: {start_time.strftime('%Y-%m-%d %H:%M')} to {end_time.strftime('%Y-%m-%d %H:%M')}")
-            
+
+            logger.debug(
+                f"Git time range: {start_time.strftime('%Y-%m-%d %H:%M')} to {end_time.strftime('%Y-%m-%d %H:%M')}"
+            )
+
             # Use git log with date range
             git_cmd = [
-                "git", "-C", workdir, "log", 
+                "git",
+                "-C",
+                workdir,
+                "log",
                 "--pretty=format:%H %h %s %ci",
                 f"--since={start_time.strftime('%Y-%m-%d %H:%M')}",
                 f"--until={end_time.strftime('%Y-%m-%d %H:%M')}",
-                "--no-merges"
+                "--no-merges",
             ]
-            
+
             logger.debug(f"Git command: {' '.join(git_cmd)}")
-            
-            commits = subprocess.run(git_cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=30).stdout.decode("utf-8")
-            
+
+            commits = subprocess.run(
+                git_cmd,
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=30,
+            ).stdout.decode("utf-8")
+
             logger.debug(f"Raw git output: {commits}")
-            
+
             output = ""
             commit_count = 0
             for commit in commits.split("\n"):
                 if not commit.strip():
                     continue
-                    
+
                 # Parse git output format: "hash short_hash subject date timezone"
                 parts = commit.split(" ")
                 if len(parts) < 4:
                     logger.debug(f"Skipping malformed commit line: {commit}")
                     continue
-                    
+
                 githash = parts[0]
-                short = parts[1] 
+                short = parts[1]
                 # Everything from index 2 up to the date (which has format YYYY-MM-DD)
                 subject_parts = []
                 for i, part in enumerate(parts[2:], 2):
-                    if part.startswith("2025-") or part.startswith("2024-"):  # Date part
+                    # Detect the date token generically as an ISO-like date (YYYY-MM-DD)
+                    if re.fullmatch(r"\d{4}-\d{2}-\d{2}", part):
                         break
                     subject_parts.append(part)
-                
+
                 subject = " ".join(subject_parts)
-                
+
                 # Skip some chore commits but include dependency updates
-                if (subject.lower().startswith("chore") and 
-                    not any(keyword in subject.lower() for keyword in ["deps", "update", "bump"])):
+                if subject.lower().startswith("chore") and not any(
+                    keyword in subject.lower() for keyword in ["deps", "update", "bump"]
+                ):
                     continue
-                    
+
                 output += self.config.templates["commit_format"].format(
                     short=short, subject=subject, githash=githash
                 )
                 commit_count += 1
-            
+
             logger.info(f"Found {commit_count} commits in timestamp range")
-            result = self.config.templates["commits_format"].format(commits=output) if output else ""
+            result = (
+                self.config.templates["commits_format"].format(commits=output)
+                if output
+                else ""
+            )
             logger.debug(f"Timestamp commit result: {result}")
             return result
-            
+
         except Exception as e:
             logger.warning(f"Timestamp-based commit search failed: {e}")
             return ""
-    
+
     def _get_commit_hash(self, manifests: Dict[str, Any]) -> str:
         """Extract commit hash from manifest labels."""
         if not manifests:
             return ""
-            
+
         manifest = next(iter(manifests.values()))
         labels = manifest.get("Labels", {})
-        
+
         # Try different label keys for commit hash
-        commit_hash = (labels.get("org.opencontainers.image.revision") or 
-                      labels.get("ostree.commit") or 
-                      labels.get("org.opencontainers.image.source") or "")
-        
+        commit_hash = (
+            labels.get("org.opencontainers.image.revision")
+            or labels.get("ostree.commit")
+            or labels.get("org.opencontainers.image.source")
+            or ""
+        )
+
         logger.debug(f"Available labels: {list(labels.keys())}")
         logger.debug(f"Extracted commit hash: {commit_hash}")
-        
+
         return commit_hash
-    
+
     def _get_container_timestamp(self, manifests: Dict[str, Any]) -> str:
         """Extract creation timestamp from manifest."""
         if not manifests:
             return ""
-            
+
         manifest = next(iter(manifests.values()))
         return manifest.get("Labels", {}).get(
-            "org.opencontainers.image.created",
-            manifest.get("Created", "")
+            "org.opencontainers.image.created", manifest.get("Created", "")
         )
 
-    def get_hwe_kernel_change(self, prev: str, curr: str, target: str) -> Tuple[Optional[str], Optional[str]]:
+    def get_hwe_kernel_change(
+        self, prev: str, curr: str, target: str
+    ) -> Tuple[Optional[str], Optional[str]]:
         """Get HWE kernel version changes."""
         try:
-            logger.info(f"Fetching HWE manifests for {curr}-hwe and {prev}-hwe...")
-            hwe_curr_manifest = self.get_manifests(curr + "-hwe")
-            hwe_prev_manifest = self.get_manifests(prev + "-hwe")
-            
+            # Convert tag format: "lts.20260216" → "lts-hwe.20260216"
+            hwe_curr = curr.replace(target + ".", target + "-hwe.", 1)
+            hwe_prev = prev.replace(target + ".", target + "-hwe.", 1)
+
+            logger.info(f"Fetching HWE manifests for {hwe_curr} and {hwe_prev}...")
+            hwe_curr_manifest = self.get_manifests(hwe_curr)
+            hwe_prev_manifest = self.get_manifests(hwe_prev)
+
             # If either manifest is empty, return None values
             if not hwe_curr_manifest or not hwe_prev_manifest:
                 logger.warning("One or both HWE manifests are empty")
                 return (None, None)
-                
+
             hwe_curr_versions = self.get_versions(hwe_curr_manifest)
             hwe_prev_versions = self.get_versions(hwe_prev_manifest)
-            
+
             curr_kernel = hwe_curr_versions.get("kernel")
             prev_kernel = hwe_prev_versions.get("kernel")
             logger.debug(f"HWE kernel versions: {prev_kernel} -> {curr_kernel}")
-            
+
             return (curr_kernel, prev_kernel)
         except Exception as e:
             logger.error(f"Failed to get HWE kernel versions: {e}")
             return (None, None)
-    
+
     def _generate_pretty_version(self, manifests: Dict[str, Any], curr: str) -> str:
         """Generate a pretty version string if not provided."""
         try:
@@ -620,147 +713,237 @@ class ChangelogGenerator:
         except Exception as e:
             logger.error(f"Failed to get finish hash: {e}")
             finish = ""
-            
+
         try:
             linux = next(iter(manifests.values()))["Labels"]["ostree.linux"]
             start = linux.find(".el") + 3
-            fedora_version = linux[start:start+2]
+            fedora_version = linux[start : start + 2]
         except Exception as e:
             logger.error(f"Failed to get linux version: {e}")
             fedora_version = ""
-        
+
         # Remove .0 from curr and target prefix
         curr_pretty = re.sub(r"\.\d{1,2}$", "", curr)
         curr_pretty = re.sub(r"^[a-z]+.|^[0-9]+\.", "", curr_pretty)
-        
+
         pretty = curr_pretty + " (c" + fedora_version + "s"
         if finish:
             pretty += ", #" + finish[:7]
         pretty += ")"
-        
+
         return pretty
 
-    def _process_template_variables(self, changelog: str, prev: str, curr: str, 
-                                   hwe_kernel_version: Optional[str], 
-                                   hwe_prev_kernel_version: Optional[str],
-                                   versions: Dict[str, str], 
-                                   prev_versions: Dict[str, str]) -> str:
+    def _process_template_variables(
+        self,
+        changelog: str,
+        prev: str,
+        curr: str,
+        hwe_kernel_version: Optional[str],
+        hwe_prev_kernel_version: Optional[str],
+        versions: Dict[str, str],
+        prev_versions: Dict[str, str],
+    ) -> str:
         """Process all template variable replacements in the changelog."""
         # Handle HWE kernel version
         if hwe_kernel_version == hwe_prev_kernel_version:
             changelog = changelog.replace(
-                "{pkgrel:kernel-hwe}", 
-                self.config.templates["pattern_pkgrel"].format(version=hwe_kernel_version or "N/A")
+                "{pkgrel:kernel-hwe}",
+                self.config.templates["pattern_pkgrel"].format(
+                    version=hwe_kernel_version or "N/A"
+                ),
             )
         else:
             changelog = changelog.replace(
                 "{pkgrel:kernel-hwe}",
                 self.config.templates["pattern_pkgrel_changed"].format(
-                    prev=hwe_prev_kernel_version or "N/A", 
-                    new=hwe_kernel_version or "N/A"
+                    prev=hwe_prev_kernel_version or "N/A",
+                    new=hwe_kernel_version or "N/A",
                 ),
             )
-        
+
         # Replace package version templates
         for pkg, version in versions.items():
             template = f"{{pkgrel:{pkg}}}"
             if pkg not in prev_versions or prev_versions[pkg] == version:
-                replacement = self.config.templates["pattern_pkgrel"].format(version=version)
+                replacement = self.config.templates["pattern_pkgrel"].format(
+                    version=version
+                )
             else:
                 replacement = self.config.templates["pattern_pkgrel_changed"].format(
                     prev=prev_versions[pkg], new=version
                 )
             changelog = changelog.replace(template, replacement)
-        
+
         # Replace any remaining unreplaced template variables with "N/A"
-        changelog = re.sub(r'\{pkgrel:[^}]+\}', 'N/A', changelog)
+        changelog = re.sub(r"\{pkgrel:[^}]+\}", "N/A", changelog)
         return changelog
 
-    def _generate_changes_section(self, prev_manifests: Dict[str, Any], 
-                                 manifests: Dict[str, Any], target: str, workdir: Optional[str],
-                                 common: List[str], others: Dict[str, List[str]],
-                                 prev_versions: Dict[str, str], 
-                                 versions: Dict[str, str]) -> str:
+    def _generate_changes_section(
+        self,
+        prev_manifests: Dict[str, Any],
+        manifests: Dict[str, Any],
+        target: str,
+        workdir: Optional[str],
+        common: List[str],
+        others: Dict[str, List[str]],
+        prev_versions: Dict[str, str],
+        versions: Dict[str, str],
+    ) -> str:
         """Generate the changes section of the changelog."""
         changes = ""
-        
+
         # Add package changes first
         common_changes = self.calculate_changes(common, prev_versions, versions)
         if common_changes:
-            changes += self.config.templates["common_pattern"].format(title=self.config.sections["all"], changes=common_changes)
-            
+            changes += self.config.templates["common_pattern"].format(
+                title=self.config.sections["all"], changes=common_changes
+            )
+
         for k, v in others.items():
             chg = self.calculate_changes(v, prev_versions, versions)
             if chg:
-                changes += self.config.templates["common_pattern"].format(title=self.config.sections[k], changes=chg)
-        
+                changes += self.config.templates["common_pattern"].format(
+                    title=self.config.sections[k], changes=chg
+                )
+
         # Add commits section after all package changes
         commits_result = self.get_commits(prev_manifests, manifests, target, workdir)
         logger.debug(f"Commits result from get_commits: '{commits_result}'")
         changes += commits_result
-        
+
         return changes
 
-    def generate_changelog(self, handwritten: Optional[str], target: str,
-                          pretty: Optional[str], workdir: Optional[str],
-                          prev_manifests: Dict[str, Any], 
-                          manifests: Dict[str, Any], 
-                          previous_tag: Optional[str] = None) -> Tuple[str, str]:
+    def generate_changelog(
+        self,
+        handwritten: Optional[str],
+        target: str,
+        pretty: Optional[str],
+        workdir: Optional[str],
+        prev_manifests: Dict[str, Any],
+        manifests: Dict[str, Any],
+        previous_tag: Optional[str] = None,
+    ) -> Tuple[str, str]:
         """Generate the complete changelog."""
         logger.info(f"Generating changelog for target '{target}'")
-        
+
         try:
             # Get package data
             common, others = self.get_package_groups(target, prev_manifests, manifests)
             versions = self.get_versions(manifests)
             prev_versions = self.get_versions(prev_manifests)
-            
+
             # Get tags and versions
             prev, curr = self.get_tags(target, manifests, previous_tag)
             logger.info(f"Tags: {prev} -> {curr}")
-            
+
             hwe_kernel_version, hwe_prev_kernel_version = self.get_hwe_kernel_change(
                 prev, curr, target
             )
-            
+
             # Generate title
             version = target.capitalize()
             if target in self.config.targets:
                 version = version.upper()
-                
+
             if not pretty:
                 pretty = self._generate_pretty_version(manifests, curr)
-                
+
             title = self.config.templates["changelog_title"].format_map(
                 defaultdict(str, os=self.config.os_name, tag=version, pretty=pretty)
             )
-            
+
             # Process base template
             changelog = self.config.templates["changelog_format"]
             changelog = (
-                changelog.replace("{handwritten}", 
-                                handwritten if handwritten else self.config.templates["handwritten_placeholder"].format(curr=curr))
+                changelog.replace(
+                    "{handwritten}",
+                    handwritten
+                    if handwritten
+                    else self.config.templates["handwritten_placeholder"].format(
+                        curr=curr
+                    ),
+                )
                 .replace("{target}", target)
                 .replace("{prev}", prev)
                 .replace("{curr}", curr)
             )
-            
+
             # Process template variables
             changelog = self._process_template_variables(
-                changelog, prev, curr, hwe_kernel_version, hwe_prev_kernel_version,
-                versions, prev_versions
+                changelog,
+                prev,
+                curr,
+                hwe_kernel_version,
+                hwe_prev_kernel_version,
+                versions,
+                prev_versions,
             )
-            
+
             # Generate and insert changes section
             changes = self._generate_changes_section(
-                prev_manifests, manifests, target, workdir, common, others, 
-                prev_versions, versions
+                prev_manifests,
+                manifests,
+                target,
+                workdir,
+                common,
+                others,
+                prev_versions,
+                versions,
             )
             changelog = changelog.replace("{changes}", changes)
-            
+
+            # Generate and insert HWE kernel table
+            if hwe_kernel_version is not None and hwe_prev_kernel_version is not None:
+                # HWE data available - generate the table
+                hwe_table = self.config.templates["hwe_kernel_table"]
+
+                # Process the HWE kernel version placeholders
+                # (standard kernel placeholder should already be processed)
+                if hwe_kernel_version == hwe_prev_kernel_version:
+                    hwe_table = hwe_table.replace(
+                        "{pkgrel:kernel-hwe}",
+                        self.config.templates["pattern_pkgrel"].format(
+                            version=hwe_kernel_version
+                        ),
+                    )
+                else:
+                    hwe_table = hwe_table.replace(
+                        "{pkgrel:kernel-hwe}",
+                        self.config.templates["pattern_pkgrel_changed"].format(
+                            prev=hwe_prev_kernel_version,
+                            new=hwe_kernel_version,
+                        ),
+                    )
+
+                # Process standard kernel version (should already be in changelog, but ensure it's in the table)
+                kernel_version = versions.get("kernel", "N/A")
+                prev_kernel_version = prev_versions.get("kernel", "N/A")
+                if kernel_version == prev_kernel_version:
+                    hwe_table = hwe_table.replace(
+                        "{pkgrel:kernel}",
+                        self.config.templates["pattern_pkgrel"].format(
+                            version=kernel_version
+                        ),
+                    )
+                else:
+                    hwe_table = hwe_table.replace(
+                        "{pkgrel:kernel}",
+                        self.config.templates["pattern_pkgrel_changed"].format(
+                            prev=prev_kernel_version,
+                            new=kernel_version,
+                        ),
+                    )
+
+                changelog = changelog.replace("{hwe_kernel_table}", hwe_table)
+                logger.info("HWE kernel table added to changelog")
+            else:
+                # No HWE data available - remove the placeholder
+                changelog = changelog.replace("{hwe_kernel_table}", "")
+                logger.info("HWE kernel data not available, table omitted")
+
             logger.info("Changelog generated successfully")
             return title, changelog
-            
+
         except Exception as e:
             logger.error(f"Failed to generate changelog: {e}")
             raise ChangelogError(f"Changelog generation failed: {e}") from e
@@ -782,34 +965,52 @@ Examples:
   # With custom options
   %(prog)s lts --workdir /path/to/git/repo --verbose
   %(prog)s lts --pretty "Custom Version" --handwritten notes.txt
-        """
+        """,
     )
-    
+
     # Required arguments
     parser.add_argument("target", help="Target tag to generate changelog for")
-    
+
     # Optional arguments
     parser.add_argument("--pretty", help="Custom subject for the changelog")
     parser.add_argument("--workdir", help="Git directory for commit extraction")
     parser.add_argument("--handwritten", help="Path to handwritten changelog content")
-    parser.add_argument("--previous-tag", help="Previous tag to compare against (overrides automatic detection)")
-    
+    parser.add_argument(
+        "--previous-tag",
+        help="Previous tag to compare against (overrides automatic detection)",
+    )
+
     # Output control
-    parser.add_argument("--verbose", "-v", action="store_true",
-                       help="Enable verbose logging")
-    parser.add_argument("--dry-run", action="store_true",
-                       help="Generate changelog but don't write files")
-    
+    parser.add_argument(
+        "--verbose", "-v", action="store_true", help="Enable verbose logging"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Generate changelog but don't write files",
+    )
+
     # Release management options
-    parser.add_argument("--check-release", action="store_true",
-                       help="Check if release already exists before generating changelog")
-    parser.add_argument("--force", action="store_true",
-                       help="Generate changelog even if release already exists")
-    parser.add_argument("--github-output", 
-                       help="Path to GitHub Actions output file for setting variables")
-    parser.add_argument("--ci", action="store_true",
-                       help="Enable CI/CD mode (equivalent to --check-release --workdir . --github-output $GITHUB_OUTPUT)")
-    
+    parser.add_argument(
+        "--check-release",
+        action="store_true",
+        help="Check if release already exists before generating changelog",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Generate changelog even if release already exists",
+    )
+    parser.add_argument(
+        "--github-output",
+        help="Path to GitHub Actions output file for setting variables",
+    )
+    parser.add_argument(
+        "--ci",
+        action="store_true",
+        help="Enable CI/CD mode (equivalent to --check-release --workdir . --github-output $GITHUB_OUTPUT)",
+    )
+
     return parser
 
 
@@ -817,56 +1018,60 @@ def validate_arguments(args: argparse.Namespace) -> None:
     """Validate command line arguments."""
     # Validate workdir if provided
     if args.workdir and not Path(args.workdir).is_dir():
-        raise ValueError(f"Workdir does not exist or is not a directory: {args.workdir}")
-    
+        raise ValueError(
+            f"Workdir does not exist or is not a directory: {args.workdir}"
+        )
+
     # Validate handwritten content if provided
     if args.handwritten:
         handwritten_path = Path(args.handwritten)
         if not handwritten_path.exists():
-            raise ValueError(f"Handwritten changelog file not found: {args.handwritten}")
+            raise ValueError(
+                f"Handwritten changelog file not found: {args.handwritten}"
+            )
 
 
 def main():
     """Main entry point for the changelog generator."""
     parser = setup_argument_parser()
     args = parser.parse_args()
-    
+
     try:
         # Validate arguments
         validate_arguments(args)
-        
+
         # Handle CI mode - apply common CI/CD defaults
         if args.ci:
             args.check_release = True
             if not args.workdir:
                 args.workdir = "."
-            if not args.github_output and os.getenv('GITHUB_OUTPUT'):
-                args.github_output = os.getenv('GITHUB_OUTPUT')
-        
+            if not args.github_output and os.getenv("GITHUB_OUTPUT"):
+                args.github_output = os.getenv("GITHUB_OUTPUT")
+
         # Configure logging based on verbosity
         if args.verbose:
             logging.getLogger().setLevel(logging.DEBUG)
-        
+
         # Remove refs/tags, refs/heads, refs/remotes etc.
-        target = args.target.split('/')[-1]
+        target = args.target.split("/")[-1]
         logger.info(f"Processing target: {target}")
-        
+
         # Create configuration with defaults
         config = load_config()
-        
+
         # Load handwritten content if provided
         handwritten = None
         if args.handwritten:
             handwritten_path = Path(args.handwritten)
-            handwritten = handwritten_path.read_text(encoding='utf-8')
+            handwritten = handwritten_path.read_text(encoding="utf-8")
             logger.info(f"Loaded handwritten content from {args.handwritten}")
-        
+
         # Create generator and process
         generator = ChangelogGenerator(config)
-        
+
         logger.info("Fetching current manifests...")
         manifests = generator.get_manifests(target)
-        
+
         # Determine previous tag - use provided one or auto-detect
         if args.previous_tag:
             prev = args.previous_tag
@@ -874,69 +1079,84 @@ def main():
         else:
             prev, curr = generator.get_tags(target, manifests)
             logger.info(f"Auto-detected previous tag: {prev}")
-        
+
         # Always get current tag from manifests
         _, curr = generator.get_tags(target, manifests, prev)
         logger.info(f"Current tag: {curr}")
-        
+
         # Check if release already exists (if requested)
         if args.check_release and not args.force:
             if check_github_release_exists(curr):
-                logger.info(f"Release already exists for tag {curr}. Skipping changelog generation.")
+                logger.info(
+                    f"Release already exists for tag {curr}. Skipping changelog generation."
+                )
                 if args.github_output:
-                    write_github_output(args.github_output, {
-                        "SKIP_CHANGELOG": "true",
-                        "CHANGELOG_TAG": curr,
-                        "EXISTING_RELEASE": "true"
-                    })
+                    write_github_output(
+                        args.github_output,
+                        {
+                            "SKIP_CHANGELOG": "true",
+                            "CHANGELOG_TAG": curr,
+                            "EXISTING_RELEASE": "true",
+                        },
+                    )
                 return
             else:
-                logger.info(f"No existing release found for {curr}. Generating changelog.")
-        
+                logger.info(
+                    f"No existing release found for {curr}. Generating changelog."
+                )
+
         # Use last published release as previous tag if not specified and check-release is enabled
         if args.check_release and not args.previous_tag:
             last_published = get_last_published_release_tag()
             if last_published:
                 prev = last_published
                 logger.info(f"Using last published release as previous tag: {prev}")
-        
+
         logger.info("Fetching previous manifests...")
         prev_manifests = generator.get_manifests(prev)
-        
+
         logger.info("Generating changelog...")
         title, changelog = generator.generate_changelog(
-            handwritten, target, args.pretty, args.workdir,
-            prev_manifests, manifests, args.previous_tag
+            handwritten,
+            target,
+            args.pretty,
+            args.workdir,
+            prev_manifests,
+            manifests,
+            args.previous_tag,
         )
-        
+
         if not args.verbose:
             print(f"Changelog Title: {title}")
             print(f"Tag: {curr}")
-        
+
         # Write output files unless dry-run
         if not args.dry_run:
             # Use paths from config
             changelog_path = Path(config.defaults["output_file"])
-            changelog_path.write_text(changelog, encoding='utf-8')
+            changelog_path.write_text(changelog, encoding="utf-8")
             logger.info(f"Changelog written to {changelog_path}")
-            
+
             output_path = Path(config.defaults["env_output_file"])
             output_content = f'TITLE="{title}"\nTAG={curr}\n'
-            output_path.write_text(output_content, encoding='utf-8')
+            output_path.write_text(output_content, encoding="utf-8")
             logger.info(f"Environment variables written to {output_path}")
-            
+
             # Write GitHub Actions output if requested
             if args.github_output:
-                write_github_output(args.github_output, {
-                    "SKIP_CHANGELOG": "false",
-                    "CHANGELOG_TAG": curr,
-                    "CHANGELOG_TITLE": title,
-                    "CHANGELOG_PATH": str(changelog_path.absolute()),
-                    "EXISTING_RELEASE": "false"
-                })
+                write_github_output(
+                    args.github_output,
+                    {
+                        "SKIP_CHANGELOG": "false",
+                        "CHANGELOG_TAG": curr,
+                        "CHANGELOG_TITLE": title,
+                        "CHANGELOG_PATH": str(changelog_path.absolute()),
+                        "EXISTING_RELEASE": "false",
+                    },
+                )
         else:
             logger.info("Dry run - no files written")
-            
+
     except (ChangelogError, TagDiscoveryError, ManifestFetchError) as e:
         logger.error(f"Changelog generation failed: {e}")
         sys.exit(1)
@@ -947,6 +1167,7 @@ def main():
         logger.error(f"Unexpected error: {e}")
         if args.verbose:
             import traceback
+
             traceback.print_exc()
         sys.exit(1)
 

--- a/.github/workflows/generate-release.yml
+++ b/.github/workflows/generate-release.yml
@@ -1,0 +1,106 @@
+name: Generate Release
+
+permissions:
+  contents: write
+
+on:
+  workflow_run:
+    workflows: ["Build Bluefin LTS GDX"]
+    types:
+      - completed
+    branches:
+      - lts
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Target to generate changelog for'
+        required: true
+        default: 'lts'
+        type: choice
+        options:
+          - lts
+          - dx
+          - gdx
+
+jobs:
+  generate-release:
+    runs-on: ubuntu-latest
+    # Only run if the workflow was successful and on lts branch
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' && 
+       github.event.workflow_run.head_branch == 'lts')
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: lts
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install PyYAML
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y skopeo jq
+
+      - name: Determine target
+        id: target
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "target=${{ inputs.target }}" >> $GITHUB_OUTPUT
+          else
+            echo "target=lts" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Generate changelog
+        run: |
+          python3 .github/changelogs.py ${{ steps.target.outputs.target }} --ci
+
+      - name: Read changelog outputs
+        id: changelog
+        run: |
+          # Source the output.env file to get TAG and TITLE
+          if [ -f output.env ]; then
+            cat output.env >> $GITHUB_OUTPUT
+          else
+            echo "output.env not found; assuming changelog generation was skipped"
+            echo "skip_release=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create GitHub Release
+        if: steps.changelog.outputs.skip_release != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ steps.changelog.outputs.TAG }}"
+          TITLE="${{ steps.changelog.outputs.TITLE }}"
+          
+          # Check if release already exists
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists, skipping creation"
+            exit 0
+          fi
+          
+          # Create the release
+          gh release create "$TAG" \
+            --title "$TITLE" \
+            --notes-file changelog.md \
+            --target lts
+
+      - name: Upload changelog artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: changelog
+          path: |
+            changelog.md
+            output.env


### PR DESCRIPTION
This fixes the changelog and adds an HWE table for the kernel. 


## Test Plan
- [x] `just check` passes
- [x] `just lint` passes (pre-existing warnings only)
- [x] `python3 .github/changelogs.py lts --dry-run --workdir .` generates valid changelog
- [x] HWE table renders correctly with current tags
- [x] HWE table gracefully omitted for older releases without HWE images

Assisted-by: Claude Opus 4.6 via OpenCode