### PR TITLE
feat: migrate changelog generation to external action

### DIFF
--- a/.github/workflows/generate-release.yml
+++ b/.github/workflows/generate-release.yml
@@ -63,8 +63,11 @@ jobs:
           fi
 
       - name: Generate changelog
-        run: |
-          python3 .github/changelogs.py ${{ steps.target.outputs.target }} --ci
+        uses: hanthor/changelog-action@master
+        with:
+          stream: ${{ steps.target.outputs.target }}
+          family: bluefin-lts
+          output-env: ./output.env
 
       - name: Read changelog outputs
         id: changelog


### PR DESCRIPTION
Migrates the changelog python script out of the repository and instead uses `hanthor/changelog-action`. This cleans up the workflow and adds support for handling `zstd` compressed sboms natively in the github action.