### PR TITLE
revert: restore SBOM generation on main branch

### DIFF
--- a/.github/workflows/build-dx-hwe.yml
+++ b/.github/workflows/build-dx-hwe.yml
@@ -13,8 +13,7 @@ on:
   push:
     branches:
       - main
-  schedule:
-    - cron: '0 2 * * 0'  # Weekly on Sunday at 2 AM UTC
+      - lts
   merge_group:
   workflow_dispatch:
 
@@ -34,7 +33,7 @@ jobs:
       image-name: bluefin-dx
       flavor: dx
       kernel-pin: 6.17.12-200.fc42
-      rechunk: ${{ github.event_name != 'pull_request' && (github.ref != 'refs/heads/lts' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
-      sbom: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/lts' }}
-      publish: ${{ github.event_name != 'pull_request' && (github.ref != 'refs/heads/lts' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
+      rechunk: ${{ github.event_name != 'pull_request' }}
+      sbom: ${{ github.event_name != 'pull_request' }}
+      publish: ${{ github.event_name != 'pull_request' }}
       hwe: true

--- a/.github/workflows/build-dx.yml
+++ b/.github/workflows/build-dx.yml
@@ -13,8 +13,7 @@ on:
   push:
     branches:
       - main
-  schedule:
-    - cron: '0 2 * * 0'  # Weekly on Sunday at 2 AM UTC
+      - lts
   merge_group:
   workflow_dispatch:
 
@@ -29,6 +28,6 @@ jobs:
     with:
       image-name: bluefin-dx
       flavor: dx
-      rechunk: ${{ github.event_name != 'pull_request' && (github.ref != 'refs/heads/lts' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
-      sbom: ${{ github.event_name != 'pull_request' && (github.ref != 'refs/heads/lts' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
-      publish: ${{ github.event_name != 'pull_request' && (github.ref != 'refs/heads/lts' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
+      rechunk: ${{ github.event_name != 'pull_request' }}
+      sbom: ${{ github.event_name != 'pull_request' }}
+      publish: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build-gdx.yml
+++ b/.github/workflows/build-gdx.yml
@@ -13,8 +13,7 @@ on:
   push:
     branches:
       - main
-  schedule:
-    - cron: '0 2 * * 0'  # Weekly on Sunday at 2 AM UTC
+      - lts
   merge_group:
   workflow_dispatch:
 
@@ -30,6 +29,6 @@ jobs:
       image-name: bluefin-gdx
       flavor: gdx
       kernel-pin: 6.17.12-200.fc42
-      rechunk: ${{ github.event_name != 'pull_request' && (github.ref != 'refs/heads/lts' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
-      sbom: ${{ github.event_name != 'pull_request' && (github.ref != 'refs/heads/lts' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
-      publish: ${{ github.event_name != 'pull_request' && (github.ref != 'refs/heads/lts' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
+      rechunk: ${{ github.event_name != 'pull_request' }}
+      sbom: ${{ github.event_name != 'pull_request' }}
+      publish: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build-regular-hwe.yml
+++ b/.github/workflows/build-regular-hwe.yml
@@ -13,8 +13,7 @@ on:
   push:
     branches:
       - main
-  schedule:
-    - cron: '0 2 * * 0'  # Weekly on Sunday at 2 AM UTC
+      - lts
   merge_group:
   workflow_dispatch:
 
@@ -33,8 +32,8 @@ jobs:
     with:
       image-name: bluefin
       kernel-pin: 6.17.12-200.fc42
-      rechunk: ${{ github.event_name != 'pull_request' && (github.ref != 'refs/heads/lts' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
-      sbom: ${{ github.event_name != 'pull_request' && (github.ref != 'refs/heads/lts' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
-      publish: ${{ github.event_name != 'pull_request' && (github.ref != 'refs/heads/lts' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
+      rechunk: ${{ github.event_name != 'pull_request' }}
+      sbom: ${{ github.event_name != 'pull_request' }}
+      publish: ${{ github.event_name != 'pull_request' }}
       hwe: true
 

--- a/.github/workflows/build-regular.yml
+++ b/.github/workflows/build-regular.yml
@@ -13,8 +13,7 @@ on:
   push:
     branches:
       - main
-  schedule:
-    - cron: '0 2 * * 0'  # Weekly on Sunday at 2 AM UTC
+      - lts
   merge_group:
   workflow_dispatch:
 
@@ -28,6 +27,6 @@ jobs:
     secrets: inherit
     with:
       image-name: bluefin
-      rechunk: ${{ github.event_name != 'pull_request' && (github.ref != 'refs/heads/lts' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
-      sbom: ${{ github.event_name != 'pull_request' && (github.ref != 'refs/heads/lts' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
-      publish: ${{ github.event_name != 'pull_request' && (github.ref != 'refs/heads/lts' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
+      rechunk: ${{ github.event_name != 'pull_request' }}
+      sbom: ${{ github.event_name != 'pull_request' }}
+      publish: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
## Summary
This reverts commit 16aa2b3 (PR #1140) to restore the original SBOM generation behavior.

## Reason for Revert
The previous PR was merged without proper review. Opening this revert so the change can be properly reviewed by Copilot and maintainers before proceeding.

## What This Revert Does
Restores the original SBOM generation logic in all workflow files:
- `build-dx-hwe.yml` - back to generating SBOMs on main branch
- All other workflows - back to their previous state

## Next Steps
After this revert is merged, a new PR will be opened with the SBOM fix for proper review.