### PR TITLE
fix(ci): prevent production LTS tag pollution from main branch merges

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -369,10 +369,10 @@ jobs:
             export DEFAULT_TAG="${DEFAULT_TAG}-hwe"
             export CENTOS_VERSION_SUFFIX="-hwe"
           fi
-          if [ "${REF_NAME}" != "${PRODUCTION_BRANCH}" ] && [ "$EVENT_NAME" == "pull_request" ] || [ "${EVENT_NAME}" == "merge_group" ] ; then
+          if [ "${REF_NAME}" != "${PRODUCTION_BRANCH}" ]; then
             export TAG_SUFFIX="testing"
             export DEFAULT_TAG="${DEFAULT_TAG}-${TAG_SUFFIX}"
-            export CENTOS_VERSION_SUFFIX="-${TAG_SUFFIX}"
+            export CENTOS_VERSION_SUFFIX="${CENTOS_VERSION_SUFFIX}-${TAG_SUFFIX}"
           fi
           echo "DEFAULT_TAG=${DEFAULT_TAG}" >> "${GITHUB_ENV}"
           echo "CENTOS_VERSION_SUFFIX=${CENTOS_VERSION_SUFFIX}" >> "${GITHUB_ENV}"


### PR DESCRIPTION
## Summary

Fixes a critical bug where merges to `main` branch were accidentally pushing container images to the production `:lts` tag instead of the testing `:lts-testing` tag.

## Problem

The manifest generation step (line 372) had incorrect conditional logic:
- **Build step (line 161)**: Simple condition `if [ "${REF_NAME}" != "${PRODUCTION_BRANCH}" ]` - adds `-testing` for all non-production branches ✅
- **Manifest step (line 372)**: Complex condition that only added `-testing` for PRs/merge groups - omitted pushes to main ❌

This caused:
- Build step creates image tagged `lts-testing` ✅
- Manifest step pushes manifest with tag `lts` ❌
- **Result**: Production tag gets polluted with testing builds!

## Solution

- Line 372: Changed from complex condition to simple `if [ "${REF_NAME}" != "${PRODUCTION_BRANCH}" ]` to match build step logic
- Line 375: Fixed `CENTOS_VERSION_SUFFIX` to append suffix instead of replacing (preserves `-hwe` when present)

## Evidence

- Bug introduced in commit `0566080` (PR #1101) which fixed the build step but forgot the manifest step
- Registry shows `:lts-testing` tags exist but haven't been updated since Feb 22 (builds were cancelled)
- Production `:lts` tags show recent activity through Mar 2

## Verification

- ✅ `just check && just lint` passes
- ✅ Test script confirms push to main will now tag as `lts-testing` not `lts`