### PR TITLE
fix: fetch raw instead of blob for zram config

### DIFF
--- a/build_scripts/26-packages-post.sh
+++ b/build_scripts/26-packages-post.sh
@@ -19,7 +19,7 @@ mkdir -p /etc/flatpak/remotes.d
 curl --retry 3 -o /etc/flatpak/remotes.d/flathub.flatpakrepo "https://dl.flathub.org/repo/flathub.flatpakrepo"
 
 # There is no `-defaults` subpackage on c10s
-curl -fsSLo /usr/lib/systemd/zram-generator.conf "https://src.fedoraproject.org/rpms/zram-generator/blob/rawhide/f/zram-generator.conf"
+curl -fsSLo /usr/lib/systemd/zram-generator.conf "https://src.fedoraproject.org/rpms/zram-generator/raw/rawhide/f/zram-generator.conf"
 grep -F -e "zram-size =" /usr/lib/systemd/zram-generator.conf
 
 # https://src.fedoraproject.org/rpms/firewalld/blob/rawhide/f/firewalld.spec


### PR DESCRIPTION
This is what we are currently fetching : [zram-generator.conf.html](https://github.com/user-attachments/files/25826175/zram-generator.conf.html) </br>
(No zram in a brand new, up-to-date VM)
<img width="1229" height="738" alt="image" src="https://github.com/user-attachments/assets/7e061422-9b9a-483c-872c-a439b5fb2ee4" />


This means zram has been completely disabled in LTS for about a month.