### PR TITLE
chore(renovate): fix automerge rules and reschedule lts cron

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,24 +32,15 @@
 
   "packageRules": [
     {
+      // Auto-merge all digest/pin updates across all managers (dockerfile, github-actions, regex/Justfile)
       "automerge": true,
-      "matchUpdateTypes": ["pin", "pinDigest"]
+      "matchUpdateTypes": ["digest", "pin", "pinDigest"]
     },
     {
+      // Auto-merge minor/patch version bumps for GitHub Actions (e.g. cosign-installer v3.8 → v3.9)
       "automerge": true,
-      "matchManagers": ["dockerfile"],
-      "matchUpdateTypes": ["digest"]
-    },
-    {
-      "automerge": true,
-      "matchUpdateTypes": ["digest"],
-      "matchDepNames": [
-        "quay.io/centos-bootc/centos-bootc",
-        "quay.io/centos-bootc/bootc-image-builder",
-        "ghcr.io/projectbluefin/common",
-        "ghcr.io/ublue-os/akmods-zfs",
-        "ghcr.io/ublue-os/brew"
-      ]
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"]
     }
   ]
 }

--- a/.github/workflows/scheduled-lts-release.yml
+++ b/.github/workflows/scheduled-lts-release.yml
@@ -2,7 +2,7 @@ name: Scheduled LTS Release
 
 on:
   schedule:
-    - cron: '0 2 * * 0'  # Weekly on Sunday at 2 AM UTC
+    - cron: '0 6 * * 2'  # Weekly on Tuesday at 6 AM UTC (1 AM EST / 2 AM EDT)
   workflow_dispatch:  # Allow manual triggering
 
 permissions:


### PR DESCRIPTION
## Summary

Two fixes to improve automation on the `main` branch and LTS release schedule.

### Fix Renovate automerge rules (`.github/renovate.json5`)

The previous `packageRules` had gaps — GitHub Actions digest/version updates and the Justfile `regex` manager were not covered by any `automerge: true` rule, causing those PRs to require manual queue entry even after approval.

Replaces 3 fragmented rules with 2 clean ones:
- All `digest`/`pin`/`pinDigest` updates get `automerge: true` across all managers
- GitHub Actions `minor`/`patch` version bumps also get `automerge: true`

### Reschedule LTS release cron

Changes the weekly LTS build trigger from Sunday 2 AM UTC to Tuesday 6 AM UTC (1 AM EST / 2 AM EDT).