### PR TITLE
fix: turn off bazaar.service for now

### DIFF
--- a/build_scripts/40-services.sh
+++ b/build_scripts/40-services.sh
@@ -16,7 +16,7 @@ systemctl enable fwupd.service
 systemctl --global enable podman-auto-update.timer
 systemctl disable rpm-ostree.service
 systemctl enable dconf-update.service
-systemctl --global enable bazaar.service
+# systemctl --global enable bazaar.service
 systemctl disable mcelog.service
 systemctl enable tailscaled.service
 systemctl enable uupd.timer


### PR DESCRIPTION
This has been an ever-growing pain in the past few weeks especially. Users sometimes were hit with random timeouts that no one could ever figure out the cause for. This means that search results for bazaar will only appear in the shell when it has been explicitly started by the user beforehand.

Best to disable it and leave the option to enable it if desired.

We can revisit this later when we have found a better solution to this. Aurora has done this since a couple weeks and hasn't received a single report since then.

One user claimed that our auto updates are possibly interfering with this. We still need to investigate that.

Will likely fix/address:

https://github.com/ublue-os/bluefin/issues/4263
https://github.com/kolunmi/bazaar/issues/1005
https://github.com/ublue-os/bluefin-lts/issues/928