### PR TITLE
fix(ci): use tree-hash anchor for accurate promotion commit list

### DIFF
--- a/.github/workflows/create-lts-pr.yml
+++ b/.github/workflows/create-lts-pr.yml
@@ -32,6 +32,9 @@ jobs:
           if git diff --quiet origin/lts origin/main; then
             echo "No content difference between lts and main. Nothing to promote."
             echo "has_diff=false" >> "$GITHUB_OUTPUT"
+          elif [ -z "$(git log origin/lts..origin/main --oneline)" ]; then
+            echo "lts is ahead of or diverged from main with no commits to promote. Nothing to promote."
+            echo "has_diff=false" >> "$GITHUB_OUTPUT"
           else
             echo "has_diff=true" >> "$GITHUB_OUTPUT"
           fi
@@ -40,7 +43,20 @@ jobs:
         if: steps.diff.outputs.has_diff == 'true'
         id: commits
         run: |
-          LIST=$(git log origin/lts..origin/main --oneline)
+          # Find the most-recent commit on main whose tree hash matches the current lts tree.
+          # This is the anchor point from which we show only genuinely new commits, even after
+          # squash-merge promotions (which lose individual commit provenance in lts history).
+          LTS_TREE=$(git rev-parse origin/lts^{tree})
+          ANCHOR=$(git log origin/main --format="%H %T" --max-count=500 \
+            | awk -v t="$LTS_TREE" '$2==t{print $1; exit}')
+
+          if [ -n "$ANCHOR" ]; then
+            LIST=$(git log "${ANCHOR}..origin/main" --oneline)
+          else
+            # Fallback when the tree match isn't in recent history (e.g., first ever promotion).
+            LIST=$(git diff --name-status origin/lts origin/main)
+          fi
+
           {
             echo "list<<EOF"
             echo "$LIST"
@@ -66,7 +82,7 @@ jobs:
 
           if [ -n "$EXISTING" ]; then
             echo "Updating existing promote PR #${EXISTING}"
-            printf '%s\n' "${BODY}" | gh pr edit "$EXISTING" --body-file - || true
+            printf '%s\n' "${BODY}" | gh pr edit "$EXISTING" --body-file -
           else
             echo "Creating new draft promote PR"
             printf '%s\n' "${BODY}" | gh pr create \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,7 +140,7 @@ Promotion and production release are **intentionally decoupled**. There are two 
 **Phase 1 — Promotion (human-gated via PR):**
 1. Every push to `main` triggers `create-lts-pr.yml`
 2. The workflow checks `git diff --quiet origin/lts origin/main` (content diff, not commit graph — survives squash-merges)
-3. If content differs: a draft PR from `main` → `lts` is created (or the existing one is updated with the latest commit list)
+3. If content differs: a draft PR from `main` → `lts` is created (or the existing one is updated). The PR body lists only the commits since the last promotion by anchoring to the `main` commit whose tree hash matches the current `lts` tree — this survives squash-merge history and prevents the list from bloating.
 4. A maintainer reviews and **squash-merges** the PR — this is the human approval gate
 5. The squash-merge triggers a `push` event on `lts` — all 5 build workflows run as **validation builds** (`publish=false`). No images are published.
 


### PR DESCRIPTION
... and of course I messed it up, one more. :)

## Solution

Find the most-recent commit on `main` whose tree hash matches the current `lts` tree. Since squash-merges preserve content exactly, this is always the `main` commit that was squash-merged into `lts`. `git log` is anchored from that point, showing only genuinely new commits regardless of squash-merge history.

If no match is found within 500 commits (first-ever promotion), falls back to `git diff --name-status`.

## Also fixed

- Removed `|| true` from `gh pr edit` — failures now surface visibly instead of silently leaving the PR body stale
- Added guard: if `git diff` detects a difference but `origin/lts..origin/main` is empty (lts is ahead/diverged), skip rather than open a misleading empty PR

Addresses Copilot review comments from #1195.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Assisted-by: Claude Sonnet 4.6 via GitHub Copilot