### PR TITLE
feat: switch from GNOME 48 to GNOME 49

### DIFF
--- a/build_scripts/20-packages.sh
+++ b/build_scripts/20-packages.sh
@@ -66,9 +66,5 @@ dnf -y --enablerepo "copr:copr.fedorainfracloud.org:che:nerd-fonts" install \
 # We could get some kind of static binary for GCC but this is the cleanest and most tested alternative. This Sucks.
 dnf -y --setopt=install_weak_deps=False install gcc
 
-# Downgrade to GNOME 48 from jreilly1821/c10s-gnome COPR (enabled in 10-packages-image-base.sh)
-# This pins us to gnome-shell 48.x instead of the upstream 49.x
-dnf -y swap gnome-shell gnome-shell-48.3 --allowerasing
-# Versionlock GNOME components to prevent upgrades back to 49
-dnf -y install python3-dnf-plugin-versionlock
-dnf versionlock add gnome-shell gdm gnome-session-wayland-session
+# Versionlock GNOME 49 components to prevent upgrades to a mismatched version
+dnf versionlock add gnome-shell gdm gnome-session-wayland-session gobject-introspection gjs pango

--- a/build_scripts/overrides/base/10-packages-image-base.sh
+++ b/build_scripts/overrides/base/10-packages-image-base.sh
@@ -12,12 +12,21 @@ dnf -y install 'dnf-command(versionlock)'
 
 /run/context/build_scripts/scripts/kernel-swap.sh
 
-# GNOME 48 backport COPR
-dnf copr enable -y "jreilly1821/c10s-gnome"
-dnf -y install glib2
-dnf -y upgrade glib2
+# GNOME 49 COPR
+dnf copr enable -y "jreilly1821/c10s-gnome-49"
+
+# These upgrades MUST happen before the GNOME group install.
+# - glib2: EL10 ships 2.80.x; gnome-shell 49.x requires 2.82+ API symbols.
+# - fontconfig: COPR pango 1.57 links FcConfigSetDefaultSubstitute (added in
+#   fontconfig 2.17.0); EL10 base ships 2.15.0 — causes a symbol lookup error
+#   at gnome-shell startup.
+# - gobject-introspection / gjs: glib2 2.84+ ships both libgirepository-1.0
+#   and libgirepository-2.0. If only one is upgraded, both get loaded and
+#   double-registering GIRepository crashes gnome-shell at startup.
+dnf -y upgrade glib2 fontconfig gobject-introspection gjs
+
 # Please, dont remove this as it will break everything GNOME related
-dnf versionlock add glib2
+dnf versionlock add glib2 fontconfig
 
 # This fixes a lot of skew issues on GDX because kernel-devel wont update then
 dnf versionlock add kernel kernel-devel kernel-devel-matched kernel-core kernel-modules kernel-modules-core kernel-modules-extra kernel-uki-virt
@@ -60,6 +69,7 @@ dnf -y install \
 	"NetworkManager-adsl" \
 	"adwaita-fonts-all" \
 	"centos-backgrounds" \
+	"dbus-daemon" \
 	"gdm" \
 	"gnome-bluetooth" \
 	"gnome-color-manager" \
@@ -88,6 +98,7 @@ dnf -y install \
 	plymouth \
 	plymouth-system-theme \
 	fwupd \
+	gnome49-el10-compat \
 	systemd-{resolved,container,oomd} \
 	libcamera{,-{v4l2,gstreamer,tools}}
 


### PR DESCRIPTION
## Summary

Switch the GNOME COPR from `jreilly1821/c10s-gnome` (48.x backport) to `jreilly1821/c10s-gnome-49` which tracks Fedora F43 dist-git.

## EL10-Specific Workarounds

All of these were discovered and confirmed working through live VM testing on `quay.io/centos-bootc/centos-bootc:stream10`. GDM greeter was reached and gnome-shell started cleanly under **enforcing SELinux**.

### 1. Pre-upgrade fontconfig before group install
COPR pango 1.57 links `FcConfigSetDefaultSubstitute`, added in fontconfig 2.17.0. EL10 base ships 2.15.0, causing a symbol lookup error that prevents gnome-shell from starting. fontconfig must be upgraded (and versionlocked) before installing the GNOME stack.

### 2. Pre-upgrade gobject-introspection and gjs
glib2 2.84+ ships both `libgirepository-1.0` and `libgirepository-2.0` as separate implementations. If only glib2 is upgraded but not these, both libraries can be loaded simultaneously, causing a fatal `cannot register existing type 'GIRepository'` crash at gnome-shell startup.

### 3. Explicit dbus-daemon install
GDM's `gdm-wayland-session` requires `dbus-daemon` for the session message bus. It is only a `Recommends:` of gdm (not `Requires:`), so bootc builds prune it. Without it, GDM exits with code 64 (`Unable to run session message bus`).

### 4. gnome49-el10-compat package
A small compat package ([source](https://github.com/tuna-os/github-copr/tree/main/src/gnome-49/gnome49-el10-compat)) that bundles two EL10 fixes:

**PAM fix** — GDM 49 dynamically allocates `gdm-greeter-N` users via systemd's Varlink userdb API. `pam_unix.so` calls `unix_chkpwd` which cannot resolve these transient users and returns `PAM_AUTHINFO_UNAVAIL`, blocking the greeter session. The package overrides the `systemd-user` PAM service to use `pam_permit.so` for the account phase.

**SELinux policy module (priority 300)** — `selinux-policy` 43.1 lacks rules for GDM 49's Varlink userdb socket architecture. The module grants `xdm_t` the ability to create the socket in `/run/systemd/userdb/` and allows the required domains (`systemd_userdbd_t`, `policykit_t`, `init_t`, `systemd_user_runtimedir_t`, etc.) to connect to it. Without this, GDM crash-loops immediately under enforcing SELinux.

## Changes

| File | Change |
|---|---|
| `overrides/base/10-packages-image-base.sh` | Switch COPR; add fontconfig/gi/gjs pre-upgrade; add dbus-daemon and gnome49-el10-compat to install |
| `build_scripts/20-packages.sh` | Remove GNOME 48 swap; update versionlock to cover gi, gjs, pango |

## Testing

Tested manually on a live `centos-bootc:stream10` Lima VM:
- ✅ GDM greeter reached
- ✅ gnome-shell session started (3 processes, seat0)
- ✅ SELinux enforcing — no AVC denials for GDM/GNOME code paths
