### PR TITLE
feat: add GNOME 50 testing builds (lts-testing-50, lts-hwe-testing-50)

### DIFF
--- a/.github/workflows/build-gnome50.yml
+++ b/.github/workflows/build-gnome50.yml
@@ -12,7 +12,6 @@ on:
   push:
     branches:
       - main
-      - lts
   merge_group:
   workflow_dispatch:
 
@@ -26,16 +25,16 @@ jobs:
     secrets: inherit
     with:
       image-name: bluefin
-      tag-suffix: testing-50
-      rechunk: ${{ github.event_name != 'pull_request' }}
-      publish: ${{ (github.event_name == 'workflow_dispatch' && (github.ref == 'refs/heads/lts' || github.ref == 'refs/heads/main')) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+      tag-suffix: "50"
+      rechunk: false
+      publish: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
 
   build-hwe:
     uses: ./.github/workflows/reusable-build-image.yml
     secrets: inherit
     with:
       image-name: bluefin
-      tag-suffix: testing-50
+      tag-suffix: "50"
       hwe: true
-      rechunk: ${{ github.event_name != 'pull_request' }}
-      publish: ${{ (github.event_name == 'workflow_dispatch' && (github.ref == 'refs/heads/lts' || github.ref == 'refs/heads/main')) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+      rechunk: false
+      publish: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/build-gnome50.yml
+++ b/.github/workflows/build-gnome50.yml
@@ -1,0 +1,41 @@
+name: Build Bluefin GNOME 50 (testing)
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+      - lts
+  merge_group:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: ./.github/workflows/reusable-build-image.yml
+    secrets: inherit
+    with:
+      image-name: bluefin
+      tag-suffix: testing-50
+      rechunk: ${{ github.event_name != 'pull_request' }}
+      publish: ${{ (github.event_name == 'workflow_dispatch' && (github.ref == 'refs/heads/lts' || github.ref == 'refs/heads/main')) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+
+  build-hwe:
+    uses: ./.github/workflows/reusable-build-image.yml
+    secrets: inherit
+    with:
+      image-name: bluefin
+      tag-suffix: testing-50
+      hwe: true
+      rechunk: ${{ github.event_name != 'pull_request' }}
+      publish: ${{ (github.event_name == 'workflow_dispatch' && (github.ref == 'refs/heads/lts' || github.ref == 'refs/heads/main')) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -141,6 +141,7 @@ jobs:
           HWE: ${{ inputs.hwe }}
           EVENT_NAME: ${{ github.event_name }}
           REF_NAME: ${{ github.ref_name }}
+          INPUT_TAG_SUFFIX: ${{ inputs.tag-suffix }}
         run: |
           set -x
           just=$(which just)
@@ -156,6 +157,10 @@ jobs:
           if [ "${REF_NAME}" != "${PRODUCTION_BRANCH}" ]; then
             export TAG_SUFFIX="testing"
             export DEFAULT_TAG="${DEFAULT_TAG}-${TAG_SUFFIX}"
+          fi
+
+          if [ -n "${INPUT_TAG_SUFFIX}" ]; then
+            export DEFAULT_TAG="${DEFAULT_TAG}-${INPUT_TAG_SUFFIX}"
           fi
 
           echo "DEFAULT_TAG=${DEFAULT_TAG}" >> "${GITHUB_ENV}"
@@ -361,6 +366,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           REF_NAME: ${{ github.ref_name }}
           HWE: ${{ inputs.hwe }}
+          INPUT_TAG_SUFFIX: ${{ inputs.tag-suffix }}
         run: |
           export CENTOS_VERSION_SUFFIX=""
           if [[ "${HWE}" == "true" ]] ; then
@@ -371,6 +377,10 @@ jobs:
             export TAG_SUFFIX="testing"
             export DEFAULT_TAG="${DEFAULT_TAG}-${TAG_SUFFIX}"
             export CENTOS_VERSION_SUFFIX="${CENTOS_VERSION_SUFFIX}-${TAG_SUFFIX}"
+          fi
+          if [ -n "${INPUT_TAG_SUFFIX}" ]; then
+            export DEFAULT_TAG="${DEFAULT_TAG}-${INPUT_TAG_SUFFIX}"
+            export CENTOS_VERSION_SUFFIX="${CENTOS_VERSION_SUFFIX}-${INPUT_TAG_SUFFIX}"
           fi
           echo "DEFAULT_TAG=${DEFAULT_TAG}" >> "${GITHUB_ENV}"
           echo "CENTOS_VERSION_SUFFIX=${CENTOS_VERSION_SUFFIX}" >> "${GITHUB_ENV}"

--- a/build_scripts/20-packages.sh
+++ b/build_scripts/20-packages.sh
@@ -66,5 +66,7 @@ dnf -y --enablerepo "copr:copr.fedorainfracloud.org:che:nerd-fonts" install \
 # We could get some kind of static binary for GCC but this is the cleanest and most tested alternative. This Sucks.
 dnf -y --setopt=install_weak_deps=False install gcc
 
-# Versionlock GNOME 49 components to prevent upgrades to a mismatched version
-dnf versionlock add gnome-shell gdm gnome-session-wayland-session gobject-introspection gjs pango
+# Versionlock GNOME 50 components to prevent downgrades to EL10 base versions
+dnf versionlock add gnome-shell gdm mutter gnome-session-wayland-session \
+	gnome-settings-daemon gnome-control-center gsettings-desktop-schemas \
+	gtk4 libadwaita pango fontconfig

--- a/build_scripts/overrides/base/10-packages-image-base.sh
+++ b/build_scripts/overrides/base/10-packages-image-base.sh
@@ -12,18 +12,18 @@ dnf -y install 'dnf-command(versionlock)'
 
 /run/context/build_scripts/scripts/kernel-swap.sh
 
-# GNOME 49 COPR
-dnf copr enable -y "jreilly1821/c10s-gnome-49"
+# GNOME 50 COPR
+dnf copr enable -y "jreilly1821/c10s-gnome-50"
 
 # These upgrades MUST happen before the GNOME group install.
-# - glib2: EL10 ships 2.80.x; gnome-shell 49.x requires 2.82+ API symbols.
-# - fontconfig: COPR pango 1.57 links FcConfigSetDefaultSubstitute (added in
+# - glib2: EL10 ships 2.80.x; gnome-shell 50.x requires 2.84+ API symbols.
+# - fontconfig: COPR pango 1.57+ links FcConfigSetDefaultSubstitute (added in
 #   fontconfig 2.17.0); EL10 base ships 2.15.0 — causes a symbol lookup error
 #   at gnome-shell startup.
-# - gobject-introspection / gjs: glib2 2.84+ ships both libgirepository-1.0
-#   and libgirepository-2.0. If only one is upgraded, both get loaded and
-#   double-registering GIRepository crashes gnome-shell at startup.
-dnf -y upgrade glib2 fontconfig gobject-introspection gjs
+# - selinux-policy: COPR 43.x is required for GDM 50 userdb varlink socket
+#   architecture; EL10 base 42.x lacks the necessary policy rules.
+dnf -y install selinux-policy selinux-policy-targeted
+dnf -y upgrade glib2 fontconfig
 
 # Please, dont remove this as it will break everything GNOME related
 dnf versionlock add glib2 fontconfig
@@ -98,7 +98,7 @@ dnf -y install \
 	plymouth \
 	plymouth-system-theme \
 	fwupd \
-	gnome49-el10-compat \
+	gnome50-el10-compat \
 	systemd-{resolved,container,oomd} \
 	libcamera{,-{v4l2,gstreamer,tools}}
 


### PR DESCRIPTION
## Summary

Adds the missing EL10 workarounds to the existing GNOME 50 COPR install, and publishes two new image tags:

- `ghcr.io/ublue-os/bluefin:lts-testing-50`
- `ghcr.io/ublue-os/bluefin:lts-hwe-testing-50`

## Changes

### `build_scripts/overrides/base/10-packages-image-base.sh`

- **fontconfig pre-upgrade**: COPR pango 1.57 links `FcConfigSetDefaultSubstitute`, added in fontconfig 2.17.0. EL10 ships 2.15.0 which lacks this symbol, causing a `symbol lookup error` crash at gnome-shell startup. Must be upgraded before the GNOME group install.
- **fontconfig versionlock**: Prevents inadvertent downgrade back to 2.15.x on user update.
- **selinux-policy from COPR (pre-upgrade)**: GNOME 50's GDM uses a dynamic userdb Varlink socket architecture that requires selinux-policy 43.x. EL10 ships 42.x which lacks the necessary `xdm_t` rules, causing AVC denials that block GDM startup under enforcing mode.
- **dbus-daemon**: Required for `gdm-wayland-session` to start the session message bus. It is only a `Recommends:` of gdm (not `Requires:`), so bootc image builds prune it. Must be installed explicitly.
- **gnome50-el10-compat**: Installs two EL10-specific fixes:
  - *PAM*: Overrides `/etc/pam.d/systemd-user` account phase with `pam_permit.so` so GDM's dynamic `gdm-greeter-N` users (allocated via systemd Varlink userdb) are not rejected by `pam_unix`.
  - *SELinux module*: Grants `xdm_t` the permissions needed for the GDM 50 socket architecture (installed at priority 300 via `semodule`).

### `build_scripts/20-packages.sh`

Adds versionlock for the full GNOME 50 stack (`gnome-shell`, `gdm`, `mutter`, `gnome-session-wayland-session`, `gnome-settings-daemon`, `gnome-control-center`, `gsettings-desktop-schemas`, `gtk4`, `libadwaita`, `pango`, `fontconfig`) to prevent EL10 base versions from overwriting the COPR builds.

### `.github/workflows/build-gnome50.yml`

New workflow calling `reusable-build-image.yml` twice with `tag-suffix: testing-50`:
- Regular build → `bluefin:lts-testing-50`
- HWE build → `bluefin:lts-hwe-testing-50`

## Testing

Validated by booting a locally-built QCOW2 image in a QEMU/Lima VM:
- `gdm.service`: active (running)
- `/usr/bin/gnome-shell`: running as `gdm-greeter` user
- `SELinux`: **Enforcing**
- `gnome50-el10-compat 1.1.0` installed
- Full GNOME 50 greeter session visible via VNC

## Related

- GNOME 49 PR: #1207
- COPR project: https://copr.fedorainfracloud.org/coprs/jreilly1821/c10s-gnome-50/
- Install guide: https://github.com/jreilly1821/github-copr/blob/main/docs/gnome49-centos-bootc.md