### PR TITLE
feat: layer GNOME 50 on top of GNOME 49 base image

### DIFF
--- a/.github/workflows/build-gnome50.yml
+++ b/.github/workflows/build-gnome50.yml
@@ -1,40 +1,75 @@
 name: Build Bluefin GNOME 50 (testing)
 
+# Builds lts-testing-50 and lts-hwe-testing-50 by layering GNOME 50 on top
+# of the already-built GNOME 49 image (lts-testing / lts-hwe-testing).
+# Only runs on main branch pushes; never on lts branch.
+
 permissions:
   contents: read
   packages: write
   id-token: write
 
 on:
-  pull_request:
-    branches:
-      - main
   push:
     branches:
       - main
-  merge_group:
   workflow_dispatch:
+    inputs:
+      base-tag:
+        description: "GNOME 49 base tag to upgrade from"
+        required: false
+        default: "lts-testing"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: bluefin
+  IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
+
 jobs:
   build:
-    uses: ./.github/workflows/reusable-build-image.yml
-    secrets: inherit
-    with:
-      image-name: bluefin
-      tag-suffix: "50"
-      rechunk: false
-      publish: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+    name: Build GNOME 50 (${{ matrix.variant.tag }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        variant:
+          - tag: lts-testing-50
+            base: lts-testing
+          - tag: lts-hwe-testing-50
+            base: lts-hwe-testing
 
-  build-hwe:
-    uses: ./.github/workflows/reusable-build-image.yml
-    secrets: inherit
-    with:
-      image-name: bluefin
-      tag-suffix: "50"
-      hwe: true
-      rechunk: false
-      publish: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login -u "${{ github.actor }}" --password-stdin ${{ env.REGISTRY }}
+
+      - name: Set base image ref
+        id: base
+        run: |
+          BASE_TAG="${{ matrix.variant.base }}"
+          # Allow workflow_dispatch override for the first variant only
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.base-tag }}" ]; then
+            BASE_TAG="${{ inputs.base-tag }}"
+          fi
+          echo "ref=${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${BASE_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Build GNOME 50 image
+        run: |
+          podman build \
+            --file Containerfile.gnome50 \
+            --build-arg BASE_IMAGE="${{ steps.base.outputs.ref }}" \
+            --tag "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.variant.tag }}" \
+            .
+
+      - name: Push image
+        if: github.ref == 'refs/heads/main'
+        run: |
+          podman push \
+            "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.variant.tag }}"
+

--- a/.github/workflows/build-gnome50.yml
+++ b/.github/workflows/build-gnome50.yml
@@ -31,15 +31,23 @@ env:
 
 jobs:
   build:
-    name: Build GNOME 50 (${{ matrix.variant.tag }})
+    name: Build GNOME 50 (${{ matrix.variant.image }}:${{ matrix.variant.tag }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         variant:
-          - tag: lts-testing-50
+          - image: bluefin
+            tag: lts-testing-50
             base: lts-testing
-          - tag: lts-hwe-testing-50
+          - image: bluefin
+            tag: lts-hwe-testing-50
+            base: lts-hwe-testing
+          - image: bluefin-dx
+            tag: lts-testing-50
+            base: lts-testing
+          - image: bluefin-dx
+            tag: lts-hwe-testing-50
             base: lts-hwe-testing
 
     steps:
@@ -57,19 +65,19 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.base-tag }}" ]; then
             BASE_TAG="${{ inputs.base-tag }}"
           fi
-          echo "ref=${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${BASE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "ref=${{ env.IMAGE_REGISTRY }}/${{ matrix.variant.image }}:${BASE_TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Build GNOME 50 image
         run: |
           podman build \
             --file Containerfile.gnome50 \
             --build-arg BASE_IMAGE="${{ steps.base.outputs.ref }}" \
-            --tag "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.variant.tag }}" \
+            --tag "${{ env.IMAGE_REGISTRY }}/${{ matrix.variant.image }}:${{ matrix.variant.tag }}" \
             .
 
       - name: Push image
         if: github.ref == 'refs/heads/main'
         run: |
           podman push \
-            "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.variant.tag }}"
+            "${{ env.IMAGE_REGISTRY }}/${{ matrix.variant.image }}:${{ matrix.variant.tag }}"
 

--- a/Containerfile.gnome50
+++ b/Containerfile.gnome50
@@ -1,0 +1,16 @@
+# Builds the GNOME 50 testing image by layering on top of the GNOME 49 image.
+# This keeps the GNOME 50 image always in sync with the 49 base and avoids
+# duplicating the full build chain.
+
+ARG BASE_IMAGE="ghcr.io/ublue-os/bluefin:lts-testing"
+FROM ${BASE_IMAGE}
+
+COPY build_scripts/upgrade-gnome49-to-50.sh /tmp/upgrade-gnome49-to-50.sh
+
+RUN --mount=type=tmpfs,dst=/opt \
+    --mount=type=tmpfs,dst=/tmp \
+    --mount=type=tmpfs,dst=/var \
+    --mount=type=tmpfs,dst=/boot \
+    chmod +x /tmp/upgrade-gnome49-to-50.sh && \
+    /tmp/upgrade-gnome49-to-50.sh && \
+    rm /tmp/upgrade-gnome49-to-50.sh

--- a/build_scripts/20-packages.sh
+++ b/build_scripts/20-packages.sh
@@ -66,7 +66,5 @@ dnf -y --enablerepo "copr:copr.fedorainfracloud.org:che:nerd-fonts" install \
 # We could get some kind of static binary for GCC but this is the cleanest and most tested alternative. This Sucks.
 dnf -y --setopt=install_weak_deps=False install gcc
 
-# Versionlock GNOME 50 components to prevent downgrades to EL10 base versions
-dnf versionlock add gnome-shell gdm mutter gnome-session-wayland-session \
-	gnome-settings-daemon gnome-control-center gsettings-desktop-schemas \
-	gtk4 libadwaita pango fontconfig
+# Versionlock GNOME 49 components to prevent upgrades to a mismatched version
+dnf versionlock add gnome-shell gdm gnome-session-wayland-session gobject-introspection gjs pango

--- a/build_scripts/overrides/base/10-packages-image-base.sh
+++ b/build_scripts/overrides/base/10-packages-image-base.sh
@@ -12,18 +12,18 @@ dnf -y install 'dnf-command(versionlock)'
 
 /run/context/build_scripts/scripts/kernel-swap.sh
 
-# GNOME 50 COPR
-dnf copr enable -y "jreilly1821/c10s-gnome-50"
+# GNOME 49 COPR
+dnf copr enable -y "jreilly1821/c10s-gnome-49"
 
 # These upgrades MUST happen before the GNOME group install.
-# - glib2: EL10 ships 2.80.x; gnome-shell 50.x requires 2.84+ API symbols.
-# - fontconfig: COPR pango 1.57+ links FcConfigSetDefaultSubstitute (added in
+# - glib2: EL10 ships 2.80.x; gnome-shell 49.x requires 2.82+ API symbols.
+# - fontconfig: COPR pango 1.57 links FcConfigSetDefaultSubstitute (added in
 #   fontconfig 2.17.0); EL10 base ships 2.15.0 — causes a symbol lookup error
 #   at gnome-shell startup.
-# - selinux-policy: COPR 43.x is required for GDM 50 userdb varlink socket
-#   architecture; EL10 base 42.x lacks the necessary policy rules.
-dnf -y install selinux-policy selinux-policy-targeted
-dnf -y upgrade glib2 fontconfig
+# - gobject-introspection / gjs: glib2 2.84+ ships both libgirepository-1.0
+#   and libgirepository-2.0. If only one is upgraded, both get loaded and
+#   double-registering GIRepository crashes gnome-shell at startup.
+dnf -y upgrade glib2 fontconfig gobject-introspection gjs
 
 # Please, dont remove this as it will break everything GNOME related
 dnf versionlock add glib2 fontconfig
@@ -98,7 +98,7 @@ dnf -y install \
 	plymouth \
 	plymouth-system-theme \
 	fwupd \
-	gnome50-el10-compat \
+	gnome49-el10-compat \
 	systemd-{resolved,container,oomd} \
 	libcamera{,-{v4l2,gstreamer,tools}}
 

--- a/build_scripts/upgrade-gnome49-to-50.sh
+++ b/build_scripts/upgrade-gnome49-to-50.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+# Upgrade a GNOME 49 bluefin-lts image to GNOME 50.
+# This script is run inside Containerfile.gnome50, which FROMs the GNOME 49
+# image. It swaps the COPR, installs the GNOME 50 compat package, and
+# upgrades the GNOME stack in place.
+
+MAJOR_VERSION_NUMBER="$(sh -c '. /usr/lib/os-release ; echo ${VERSION_ID%.*}')"
+
+# Swap COPR repos
+dnf copr disable -y "jreilly1821/c10s-gnome-49"
+dnf copr enable  -y "jreilly1821/c10s-gnome-50"
+
+# selinux-policy 43.x is required for GDM 50 userdb varlink socket architecture.
+# EL10 base ships 42.x which lacks the necessary policy rules.
+dnf -y install selinux-policy selinux-policy-targeted
+
+# Remove GNOME 49 versionlocks so the upgrade can proceed
+dnf versionlock delete gnome-shell gdm gnome-session-wayland-session \
+    gobject-introspection gjs pango 2>/dev/null || true
+
+# Swap compat package
+dnf -y install gnome50-el10-compat
+dnf -y remove  gnome49-el10-compat 2>/dev/null || true
+
+# Upgrade the full GNOME stack to GNOME 50
+dnf -y upgrade gnome-shell gdm mutter gnome-session gnome-session-wayland-session \
+    gnome-settings-daemon gnome-control-center gsettings-desktop-schemas \
+    gtk4 libadwaita pango glib2 gobject-introspection gjs
+
+# Versionlock GNOME 50 components
+dnf versionlock add gnome-shell gdm mutter gnome-session-wayland-session \
+    gnome-settings-daemon gnome-control-center gsettings-desktop-schemas \
+    gtk4 libadwaita pango fontconfig
+
+# Re-compile GLib schemas after upgrading
+glib-compile-schemas /usr/share/glib-2.0/schemas/


### PR DESCRIPTION
## Summary

Switches the architecture so GNOME 49 is the primary/default build and GNOME 50 is built as a layer on top.

### Changes

**Main image (lts-testing)** → back to GNOME 49:
- `10-packages-image-base.sh`: re-enables `c10s-gnome-49` COPR, upgrades `gobject-introspection`/`gjs`, installs `gnome49-el10-compat`
- `20-packages.sh`: versionlocks GNOME 49 packages

**GNOME 50 image (lts-testing-50)** → layered upgrade:
- `Containerfile.gnome50`: `FROM ghcr.io/ublue-os/bluefin:lts-testing`, runs upgrade script
- `build_scripts/upgrade-gnome49-to-50.sh`: swaps COPR, replaces compat package, installs selinux-policy 43.x, upgrades GNOME stack in-place, sets GNOME 50 versionlocks
- `build-gnome50.yml`: direct podman build (no reusable workflow), matrix over `lts-testing-50` and `lts-hwe-testing-50`, only publishes on main

### Build order
1. Main workflow builds `lts-testing` (GNOME 49)
2. `build-gnome50.yml` builds `lts-testing-50` by upgrading `lts-testing` in place