### PR TITLE
fix: upgrade script was being wiped by /tmp tmpfs mount

### DIFF
--- a/Containerfile.gnome50
+++ b/Containerfile.gnome50
@@ -7,10 +7,6 @@ FROM ${BASE_IMAGE}
 
 COPY build_scripts/upgrade-gnome49-to-50.sh /usr/local/bin/upgrade-gnome49-to-50.sh
 
-RUN --mount=type=tmpfs,dst=/opt \
-    --mount=type=tmpfs,dst=/tmp \
-    --mount=type=tmpfs,dst=/var \
-    --mount=type=tmpfs,dst=/boot \
-    chmod +x /usr/local/bin/upgrade-gnome49-to-50.sh && \
+RUN chmod +x /usr/local/bin/upgrade-gnome49-to-50.sh && \
     /usr/local/bin/upgrade-gnome49-to-50.sh && \
     rm /usr/local/bin/upgrade-gnome49-to-50.sh

--- a/Containerfile.gnome50
+++ b/Containerfile.gnome50
@@ -5,12 +5,12 @@
 ARG BASE_IMAGE="ghcr.io/ublue-os/bluefin:lts-testing"
 FROM ${BASE_IMAGE}
 
-COPY build_scripts/upgrade-gnome49-to-50.sh /tmp/upgrade-gnome49-to-50.sh
+COPY build_scripts/upgrade-gnome49-to-50.sh /usr/local/bin/upgrade-gnome49-to-50.sh
 
 RUN --mount=type=tmpfs,dst=/opt \
     --mount=type=tmpfs,dst=/tmp \
     --mount=type=tmpfs,dst=/var \
     --mount=type=tmpfs,dst=/boot \
-    chmod +x /tmp/upgrade-gnome49-to-50.sh && \
-    /tmp/upgrade-gnome49-to-50.sh && \
-    rm /tmp/upgrade-gnome49-to-50.sh
+    chmod +x /usr/local/bin/upgrade-gnome49-to-50.sh && \
+    /usr/local/bin/upgrade-gnome49-to-50.sh && \
+    rm /usr/local/bin/upgrade-gnome49-to-50.sh


### PR DESCRIPTION
The upgrade script was COPYed to `/tmp/` but the `RUN` step mounts tmpfs over `/tmp`, wiping it before execution. Move to `/usr/local/bin/` instead.