### PR TITLE
fix: upload-artifact names for hwe/non-hwe gnome50 builds

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -320,7 +320,7 @@ jobs:
         if: ${{ inputs.publish }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
-          name: ${{ env.IMAGE_NAME }}-${{ matrix.platform }}
+          name: ${{ env.IMAGE_NAME }}-${{ matrix.platform }}${{ inputs.hwe && '-hwe' || '' }}${{ inputs.tag-suffix != '' && format('-{0}', inputs.tag-suffix) || '' }}
           retention-days: 1
           if-no-files-found: error
           path: |


### PR DESCRIPTION
When `build-gnome50.yml` runs both `build` and `build-hwe` jobs concurrently, both upload artifacts named `bluefin-amd64` (and `bluefin-arm64`), causing a 409 Conflict on the second upload.

**Fix**: Include the `hwe` flag and `tag-suffix` in the artifact name:
```
bluefin-amd64-50       (build job, regular)
bluefin-amd64-hwe-50   (build-hwe job)
bluefin-arm64-50
bluefin-arm64-hwe-50
```

The manifest job downloads with `pattern: bluefin-*` + `merge-multiple: true`, so it picks up all variants correctly. File names inside the artifacts remain unique (`bluefin-false-amd64.txt` vs `bluefin-true-amd64.txt`) so no collision there either.