### PR TITLE
feat: add bluefin-dx GNOME 50 build variants

### DIFF
--- a/.github/workflows/build-gnome50.yml
+++ b/.github/workflows/build-gnome50.yml
@@ -1,6 +1,6 @@
 name: Build Bluefin GNOME 50 (testing)
 
-# Builds bluefin:lts-testing-50 and bluefin-dx:lts-hwe-testing-50 using
+# Builds bluefin and bluefin-dx lts-testing-50 / lts-hwe-testing-50 using
 # the same full build pipeline as GNOME 49, selecting GNOME 50 packages
 # via the gnome-version input. Only runs on main branch pushes.
 
@@ -38,6 +38,29 @@ jobs:
     secrets: inherit
     with:
       image-name: bluefin
+      tag-suffix: "50"
+      gnome-version: "50"
+      hwe: true
+      rechunk: ${{ github.event_name != 'pull_request' }}
+      publish: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+
+  build-dx:
+    uses: ./.github/workflows/reusable-build-image.yml
+    secrets: inherit
+    with:
+      image-name: bluefin-dx
+      flavor: dx
+      tag-suffix: "50"
+      gnome-version: "50"
+      rechunk: ${{ github.event_name != 'pull_request' }}
+      publish: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+
+  build-dx-hwe:
+    uses: ./.github/workflows/reusable-build-image.yml
+    secrets: inherit
+    with:
+      image-name: bluefin-dx
+      flavor: dx
       tag-suffix: "50"
       gnome-version: "50"
       hwe: true


### PR DESCRIPTION
Adds `build-dx` and `build-dx-hwe` jobs to `build-gnome50.yml`, producing:

- `ghcr.io/ublue-os/bluefin-dx:lts-testing-50`
- `ghcr.io/ublue-os/bluefin-dx:lts-hwe-testing-50`

Mirrors the existing `build-dx.yml` pattern with `flavor: dx` + `gnome-version: "50"`.

Tested on fork — all 20 jobs green (4 variants × amd64 + arm64 × build + sign + manifest): https://github.com/hanthor/bluefin-lts-fork/actions/runs/23375886568