### PR TITLE
fix: install jxl-pixbuf-loader for JPEG-XL desktop backgrounds

### DIFF
--- a/build_scripts/20-packages.sh
+++ b/build_scripts/20-packages.sh
@@ -25,6 +25,7 @@ dnf -y install \
 	hplip \
 	ibus-chewing \
 	jetbrains-mono-fonts-all \
+	jxl-pixbuf-loader \
 	just \
 	nss-mdns \
 	ntfs-3g \


### PR DESCRIPTION
## Problem

`gnome-desktop4` 44.5 (EL10 base) loads desktop wallpapers via **gdk-pixbuf**, not glycin. The image already ships glycin-loaders with JXL support, but that only helps apps that use the glycin API directly (e.g. Loupe). gnome-shell's background loading goes through gnome-bg → gdk-pixbuf.

Without a gdk-pixbuf JXL loader installed, all bluefin wallpapers (which are `.jxl` files) fail to render — the desktop background is blank/black.

## Root Cause

- `glycin-loaders` ✅ — has JXL support, used by Loupe/Nautilus thumbnailer
- `gdk-pixbuf` ❌ — **no JXL loader**, used by gnome-shell for backgrounds
- `libjxl` ✅ — installed (via multimedia repo), but not wired into gdk-pixbuf

## Fix

`jxl-pixbuf-loader` (from EPEL, already enabled in the image) registers a gdk-pixbuf plugin for `image/jxl`, making gnome-shell able to display `.jxl` wallpapers from the XML background slideshow.

Tested on a live GNOME 49 / EL10 machine: `jxl-pixbuf-loader` was available via EPEL and confirmed absent — adding it resolved the blank background issue.