### PR TITLE
fix(gdx): remove stale kernel-pin, follow coreos-stable akmods

### DIFF
--- a/.github/workflows/build-gdx.yml
+++ b/.github/workflows/build-gdx.yml
@@ -27,6 +27,5 @@ jobs:
     with:
       image-name: bluefin-gdx
       flavor: gdx
-      kernel-pin: 6.17.12-200.fc42
       rechunk: ${{ github.event_name != 'pull_request' }}
       publish: ${{ (github.event_name == 'workflow_dispatch' && (github.ref == 'refs/heads/lts' || github.ref == 'refs/heads/main')) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}


### PR DESCRIPTION
## Problem

GDX builds have been failing with:
```
No match for argument: libnvidia-fbc-3:590.48.01
No match for argument: nvidia-driver-3:590.48.01
Error: Unable to find a match: libnvidia-fbc-3:590.48.01 ...
```

## Root Cause

`build-gdx.yml` had `kernel-pin: 6.17.12-200.fc42` which locked AKMODS_VERSION to:
```
akmods-nvidia-open:coreos-stable-42-6.17.12-200.fc42.x86_64
```
This container was built 2026-02-03 and contains **kmod-nvidia-590.48.01**. negativo17's Fedora 43 repo has since moved past that version and no longer carries the matching `nvidia-driver-3:590.48.01` packages.

## Fix

Remove the `kernel-pin` so GDX uses the floating `coreos-stable-42` akmods tag (same pattern as Bluefin Stable GDX). This tracks:

> CoreOS Stable kernel → Bluefin Stable kernel → HWE kernel → GDX kernel

The floating tag always ships kmod-nvidia versions that match what negativo17 currently serves, avoiding this version drift.