### PR TITLE
fix(gdx): guard nvidia-modeset.conf copy for arm64

### DIFF
--- a/build_scripts/overrides/gdx/20-nvidia.sh
+++ b/build_scripts/overrides/gdx/20-nvidia.sh
@@ -65,7 +65,10 @@ systemctl enable ublue-nvctk-cdi.service
 semodule --verbose --install /usr/share/selinux/packages/nvidia-container.pp
 
 # Universal Blue specific Initramfs fixes
-cp /etc/modprobe.d/nvidia-modeset.conf /usr/lib/modprobe.d/nvidia-modeset.conf
+# nvidia-modeset.conf may not exist on all architectures (e.g. arm64/SBSA)
+if [[ -f /etc/modprobe.d/nvidia-modeset.conf ]]; then
+    cp /etc/modprobe.d/nvidia-modeset.conf /usr/lib/modprobe.d/nvidia-modeset.conf
+fi
 # we must force driver load to fix black screen on boot for nvidia desktops
 sed -i 's@omit_drivers@force_drivers@g' /usr/lib/dracut/dracut.conf.d/99-nvidia.conf
 # as we need forced load, also mustpre-load intel/amd iGPU else chromium web browsers fail to use hardware acceleration


### PR DESCRIPTION
## Problem

GDX arm64 builds fail with:
```
cp: cannot stat '/etc/modprobe.d/nvidia-modeset.conf': No such file or directory
```

## Root Cause

On aarch64 (SBSA), the NVIDIA open driver packages do not create `/etc/modprobe.d/nvidia-modeset.conf`. The script unconditionally tries to copy it, which fails on arm64 while succeeding on x86_64.

## Fix

Guard the `cp` with a file existence check. The conf is not needed for SBSA so arm64 can safely skip it.