### PR TITLE
fix(ci): remove pull_request trigger from GNOME 50 workflow

### DIFF
--- a/.github/workflows/build-gnome50.yml
+++ b/.github/workflows/build-gnome50.yml
@@ -3,6 +3,11 @@ name: Build Bluefin GNOME 50 (testing)
 # Builds bluefin and bluefin-dx lts-testing-50 / lts-hwe-testing-50 using
 # the same full build pipeline as GNOME 49, selecting GNOME 50 packages
 # via the gnome-version input. Only runs on main branch pushes.
+#
+# pull_request and merge_group triggers intentionally omitted: the GNOME 50
+# build currently fails with a dracut cross-device link error (EXDEV) on
+# GitHub Actions runners, which blocks all Renovate PRs from auto-merging.
+# This workflow runs post-merge (push) only until the build issue is resolved.
 
 permissions:
   contents: read
@@ -14,10 +19,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
-  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}


### PR DESCRIPTION
This makes it so we can run 50 but not block the testing workflow. 




Agent results below:



The **Build Bluefin GNOME 50 (testing)** workflow runs on every PR via \`pull_request\` and \`merge_group\` triggers. It currently fails with:

\`\`\`
error: rpm-ostree kernel-install: Adding kernel: Running dracut: Invalid cross-device link (os error 18)
\`\`\`

This is a dracut/kernel-install failure (POSIX \`EXDEV\`) in the GitHub Actions runner environment, affecting both amd64 and arm64. It has been failing consistently since at least 2026-03-21.

## Impact

All 6 open Renovate PRs are blocked from auto-merging:
- #1237, #1236, #1234, #1228, #1223, #1216, #1210

The GNOME 50 workflow produces check names that collide with required checks (\`build / Create bluefin:stream10 Manifest\`), and the merge queue's \`ALLGREEN\` grouping strategy blocks on ANY failed check.

## Fix

Remove \`pull_request\` and \`merge_group\` triggers from \`build-gnome50.yml\`. The workflow now only runs **post-merge** on \`push\` to \`main\` and on \`workflow_dispatch\`.

This is safe because:
- The GNOME 50 build is a testing/experimental path, not a required gate
- It already uses \`publish: false\` for PR events (no images were being published on PRs anyway)
- Post-merge runs will still validate and publish the GNOME 50 testing images to GHCR

## Follow-up

Once the dracut EXDEV issue is resolved upstream (likely a runner environment or Containerfile fix), the \`pull_request\` trigger can be restored.