### PR TITLE
fix: upgrade selinux-policy to 43.x for GNOME 49 to resolve GDM failure

### DIFF
--- a/build_scripts/20-packages.sh
+++ b/build_scripts/20-packages.sh
@@ -71,8 +71,8 @@ if [[ "${GNOME_VERSION:-49}" == "50" ]]; then
     # Versionlock GNOME 50 components to prevent downgrades to EL10 base versions
     dnf versionlock add gnome-shell gdm mutter gnome-session-wayland-session \
         gnome-settings-daemon gnome-control-center gsettings-desktop-schemas \
-        gtk4 libadwaita pango fontconfig
+        gtk4 libadwaita pango fontconfig selinux-policy selinux-policy-targeted gnutls
 else
     # Versionlock GNOME 49 components to prevent upgrades to a mismatched version
-    dnf versionlock add gnome-shell gdm gnome-session-wayland-session gobject-introspection gjs pango
+    dnf versionlock add gnome-shell gdm gnome-session-wayland-session gobject-introspection gjs pango fontconfig selinux-policy selinux-policy-targeted gnutls
 fi

--- a/build_scripts/overrides/base/10-packages-image-base.sh
+++ b/build_scripts/overrides/base/10-packages-image-base.sh
@@ -17,26 +17,31 @@ if [[ "${GNOME_VERSION:-49}" == "50" ]]; then
     dnf copr enable -y "jreilly1821/c10s-gnome-50-fresh"
 
     # These upgrades MUST happen before the GNOME group install.
-    # - glib2: EL10 ships 2.80.x; gnome-shell 50.x requires 2.84+ API symbols.
+    # - glib2: EL10 ships 2.80.x; GNOME 49/50 require newer API symbols.
     # - fontconfig: COPR pango 1.57+ links FcConfigSetDefaultSubstitute (added in
     #   fontconfig 2.17.0); EL10 base ships 2.15.0 — causes a symbol lookup error
     #   at gnome-shell startup.
-    # - selinux-policy: COPR 43.x is required for GDM 50 userdb varlink socket
+    # - selinux-policy: COPR 43.x is required for GDM 49/50 userdb varlink socket
     #   architecture; EL10 base 42.x lacks the necessary policy rules.
-    dnf -y install selinux-policy selinux-policy-targeted
+    # - gnutls: newer glib2 from COPR may depend on gnutls symbols not in base.
+    dnf -y install selinux-policy selinux-policy-targeted gnutls
     dnf -y upgrade glib2 fontconfig
 else
     # GNOME 49 COPR (default)
     dnf copr enable -y "jreilly1821/c10s-gnome-49"
 
     # These upgrades MUST happen before the GNOME group install.
-    # - glib2: EL10 ships 2.80.x; gnome-shell 49.x requires 2.82+ API symbols.
-    # - fontconfig: COPR pango 1.57 links FcConfigSetDefaultSubstitute (added in
+    # - glib2: EL10 ships 2.80.x; GNOME 49/50 require newer API symbols.
+    # - fontconfig: COPR pango 1.57+ links FcConfigSetDefaultSubstitute (added in
     #   fontconfig 2.17.0); EL10 base ships 2.15.0 — causes a symbol lookup error
     #   at gnome-shell startup.
+    # - selinux-policy: COPR 43.x is required for GDM 49/50 userdb varlink socket
+    #   architecture; EL10 base 42.x lacks the necessary policy rules.
     # - gobject-introspection / gjs: glib2 2.84+ ships both libgirepository-1.0
     #   and libgirepository-2.0. If only one is upgraded, both get loaded and
     #   double-registering GIRepository crashes gnome-shell at startup.
+    # - gnutls: newer glib2 from COPR may depend on gnutls symbols not in base.
+    dnf -y install selinux-policy selinux-policy-targeted gnutls
     dnf -y upgrade glib2 fontconfig gobject-introspection gjs
 fi
 


### PR DESCRIPTION
### Summary
Upgrades `selinux-policy` and `selinux-policy-targeted` to 43.x for the GNOME 49 build path, and adds `gnutls` as a pre-upgrade dependency.

### The Problem
Bluefin LTS testing images using GNOME 49 failed to reach the GDM greeter due to SELinux denials related to the new `systemd-userdb` architecture. Additionally, GNOME 50 builds were failing due to missing `gnutls` dependencies for the updated `glib2`.

### The Solution
1. Upgraded `selinux-policy` to 43.x from COPR for both GNOME 49 and 50 paths to support the `userdb` Varlink socket architecture.
2. Added `gnutls` to the pre-upgrade section to satisfy dependencies for newer `glib2` versions.
3. Removed redundant `libjxl` exclusion logic as it is no longer present in the COPR.

### Changes
- **build_scripts/overrides/base/10-packages-image-base.sh**: Upgrades `selinux-policy`, `selinux-policy-targeted`, and `gnutls` for both GNOME 49 and 50 paths.
- **build_scripts/20-packages.sh**: Adds `selinux-policy`, `selinux-policy-targeted`, `fontconfig`, and `gnutls` to the versionlocks.

Fixes part of the boot and build issues reported in `bluefin:lts-testing`.