### PR TITLE
feat: add Bazaar Companion extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,4 +22,3 @@
 [submodule "system_files/usr/share/gnome-shell/extensions/tmp/bazaar-integration@kolunmi.github.io"]
 	path = system_files/usr/share/gnome-shell/extensions/tmp/bazaar-integration@kolunmi.github.io
 	url = https://github.com/AlexanderVanhee/bazaar-companion.git
-	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,7 @@
 [submodule "system_files/usr/share/gnome-shell/extensions/search-light@icedman.github.com"]
 	path = system_files/usr/share/gnome-shell/extensions/search-light@icedman.github.com
 	url = https://github.com/icedman/search-light.git
+[submodule "system_files/usr/share/gnome-shell/extensions/tmp/bazaar-integration@kolunmi.github.io"]
+	path = system_files/usr/share/gnome-shell/extensions/tmp/bazaar-integration@kolunmi.github.io
+	url = https://github.com/AlexanderVanhee/bazaar-companion.git
+	branch = main

--- a/build_scripts/21-build-gnome-extensions.sh
+++ b/build_scripts/21-build-gnome-extensions.sh
@@ -12,6 +12,9 @@ dnf -y install glib2-devel meson sassc cmake dbus-devel
 # AppIndicator Support
 glib-compile-schemas --strict /usr/share/gnome-shell/extensions/appindicatorsupport@rgcjonas.gmail.com/schemas
 
+# Bazaar Companion
+mv /usr/share/gnome-shell/extensions/tmp/bazaar-integration@kolunmi.github.io/src/ /usr/share/gnome-shell/extensions/bazaar-integration@kolunmi.github.io/
+
 # Blur My Shell
 make -C /usr/share/gnome-shell/extensions/blur-my-shell@aunetx
 unzip -o /usr/share/gnome-shell/extensions/blur-my-shell@aunetx/build/blur-my-shell@aunetx.shell-extension.zip -d /usr/share/gnome-shell/extensions/blur-my-shell@aunetx


### PR DESCRIPTION
Adds the Bazaar Companion GNOME Shell extension (bazaar-integration@kolunmi.github.io) which provides an 'App Details' context menu entry for Flatpak applications, letting users view details and uninstall apps directly from the right-click menu.

Port of ublue-os/bluefin#4089.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot