### PR TITLE
feat: replace cosign-attest SBOM with ORAS attach + actions/attest

### DIFF
--- a/.github/workflows/build-dx-hwe.yml
+++ b/.github/workflows/build-dx-hwe.yml
@@ -4,6 +4,7 @@ permissions:
   contents: read
   packages: write
   id-token: write
+  attestations: write
 
 on:
   pull_request:
@@ -28,6 +29,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
     with:
       image-name: bluefin-dx
       flavor: dx

--- a/.github/workflows/build-dx.yml
+++ b/.github/workflows/build-dx.yml
@@ -4,6 +4,7 @@ permissions:
   contents: read
   packages: write
   id-token: write
+  attestations: write
 
 on:
   pull_request:

--- a/.github/workflows/build-gdx.yml
+++ b/.github/workflows/build-gdx.yml
@@ -4,6 +4,7 @@ permissions:
   contents: read
   packages: write
   id-token: write
+  attestations: write
 
 on:
   pull_request:

--- a/.github/workflows/build-gnome50.yml
+++ b/.github/workflows/build-gnome50.yml
@@ -13,6 +13,7 @@ permissions:
   contents: read
   packages: write
   id-token: write
+  attestations: write
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build-regular-hwe.yml
+++ b/.github/workflows/build-regular-hwe.yml
@@ -4,6 +4,7 @@ permissions:
   contents: read
   packages: write
   id-token: write
+  attestations: write
 
 on:
   pull_request:
@@ -28,6 +29,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
     with:
       image-name: bluefin
       kernel-pin: 6.17.12-200.fc42

--- a/.github/workflows/build-regular.yml
+++ b/.github/workflows/build-regular.yml
@@ -4,6 +4,7 @@ permissions:
   contents: read
   packages: write
   id-token: write
+  attestations: write
 
 on:
   pull_request:

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -112,6 +112,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
     outputs:
       image_tag: ${{ steps.build-image.outputs.image_tag }}
 
@@ -182,23 +183,23 @@ jobs:
       - name: Setup Syft
         id: setup-syft
         if: ${{ github.ref == 'refs/heads/lts' && inputs.publish }}
-        continue-on-error: true
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0
+        with:
+          syft-version: v1.39.0
 
       - name: Generate SBOM
         id: generate-sbom
         if: ${{ github.ref == 'refs/heads/lts' && inputs.publish }}
-        continue-on-error: true
         env:
           IMAGE: ${{ env.IMAGE_NAME }}
           DEFAULT_TAG: ${{ env.DEFAULT_TAG }}
           SYFT_CMD: ${{ steps.setup-syft.outputs.cmd }}
         run: |
           sudo systemctl start podman.socket
-          OUTPUT_PATH="$(mktemp -d)/sbom.json"
+          SBOM="$(mktemp -d)/sbom.json"
           export SYFT_PARALLELISM=$(($(nproc)*2))
-          sudo "$SYFT_CMD" "${IMAGE}:${DEFAULT_TAG}" -o "spdx-json=${OUTPUT_PATH}"
-          echo "OUTPUT_PATH=${OUTPUT_PATH}" >> "${GITHUB_OUTPUT}"
+          sudo "$SYFT_CMD" "${IMAGE}:${DEFAULT_TAG}" -o "spdx-json=${SBOM}"
+          echo "SBOM=${SBOM}" >> "${GITHUB_OUTPUT}"
 
       - name: Run Rechunker
         if: ${{ inputs.rechunk && inputs.publish }}
@@ -273,37 +274,55 @@ jobs:
           COSIGN_EXPERIMENTAL: false
           COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
 
-      - name: Add SBOM Attestation
+      - name: Install ORAS
         if: ${{ github.ref == 'refs/heads/lts' && inputs.publish }}
-        continue-on-error: true
+        uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1.2.4
+
+      - name: Login to GitHub Container Registry with ORAS
+        if: ${{ github.ref == 'refs/heads/lts' && inputs.publish }}
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Upload SBOM
+        if: ${{ github.ref == 'refs/heads/lts' && inputs.publish }}
+        id: upload-sbom
         env:
           IMAGE: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
           DIGEST: ${{ steps.push.outputs.remote_image_digest }}
-          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
-          SBOM_OUTPUT: ${{ steps.generate-sbom.outputs.OUTPUT_PATH }}
+          SBOM: ${{ steps.generate-sbom.outputs.SBOM }}
         run: |
-          cd "$(dirname "$SBOM_OUTPUT")"
+          cd "$(dirname "${SBOM}")"
+          oras attach \
+            --artifact-type application/vnd.spdx+json \
+            --annotation "filename=$(basename "${SBOM}")" \
+            "${IMAGE}@${DIGEST}" \
+            "$(basename "${SBOM}")"
+          sbom_digest=$(oras discover --format json "${IMAGE}@${DIGEST}" \
+            | jq -r '[.referrers[] | select(.artifactType == "application/vnd.spdx+json") | .digest] | first')
+          if [[ -z "${sbom_digest}" || "${sbom_digest}" == "null" ]]; then
+            echo "ERROR: SBOM referrer not found after upload" >&2
+            exit 1
+          fi
+          echo "sbom_digest=${sbom_digest}" >> "${GITHUB_OUTPUT}"
 
-          # Compress the SBOM and create the predicate
-          TYPE="urn:ublue-os:attestation:spdx+json+zstd:v1"
-          zstd -19 "./sbom.json" -o "./sbom.json.zst"
-          BASE64_SBOM_FILE="payload.b64"
-          base64 "./sbom.json.zst" | tr -d '\n' > "${BASE64_SBOM_FILE}"
-          PREDICATE_FILE="payload.json"
-          jq -n \
-            --arg compression "zstd" \
-            --arg mediaType "application/spdx+json" \
-            --rawfile payload "${BASE64_SBOM_FILE}" \
-            '{compression: $compression, mediaType: $mediaType, payload: $payload}' \
-            > "$PREDICATE_FILE"
-          rm -f "${BASE64_SBOM_FILE}"
+      - name: Sign SBOM OCI Artifact
+        if: ${{ github.ref == 'refs/heads/lts' && inputs.publish }}
+        env:
+          COSIGN_EXPERIMENTAL: false
+          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
+          IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          SBOM_DIGEST: ${{ steps.upload-sbom.outputs.sbom_digest }}
+        run: |
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY "${IMAGE_REGISTRY}/${IMAGE_NAME}@${SBOM_DIGEST}"
 
-          # Create the attestation
-          cosign attest -y \
-            --predicate "${PREDICATE_FILE}" \
-            --type $TYPE \
-            --key env://COSIGN_PRIVATE_KEY \
-            "${IMAGE}@${DIGEST}"
+      - name: Attestation
+        if: ${{ github.ref == 'refs/heads/lts' && inputs.publish }}
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 #v4.1.0
+        with:
+          subject-name: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.remote_image_digest }}
+          push-to-registry: true
 
       - name: Create Job Outputs
         if: ${{ inputs.publish }}


### PR DESCRIPTION
Replaces the old zstd-compressed custom cosign predicate approach with the same ORAS-based SBOM attachment used by bluefin and aurora.

```
oras discover --format json "ghcr.io/castrojo/bluefin-gdx@sha256:6f199ff08242dc81668b0d0c85afd524e148601d5bbeca5ef3d43a5f7f5bc3dd

gh attestation verify "oci://ghcr.io/castrojo/bluefin-gdx@sha256:6f199ff08242dc81668b0d0c85afd524e148601d5bbeca5ef3d43a5f7f5bc3dd" --repo castrojo/bluefin-lts
```


