### PR TITLE
feat: install lgda from GNOME 49/50 COPRs

### DIFF
--- a/build_scripts/overrides/base/10-packages-image-base.sh
+++ b/build_scripts/overrides/base/10-packages-image-base.sh
@@ -126,9 +126,9 @@ dnf -y install \
 	libcamera{,-{v4l2,gstreamer,tools}}
 
 if [[ "${GNOME_VERSION:-49}" == "50" ]]; then
-    dnf -y install gnome50-el10-compat lgda
+    dnf -y install gnome50-el10-compat libgda
 else
-    dnf -y install gnome49-el10-compat lgda
+    dnf -y install gnome49-el10-compat libgda
 fi
 
 # This package adds "[systemd] Failed Units: *" to the bashrc startup

--- a/build_scripts/overrides/base/10-packages-image-base.sh
+++ b/build_scripts/overrides/base/10-packages-image-base.sh
@@ -126,9 +126,9 @@ dnf -y install \
 	libcamera{,-{v4l2,gstreamer,tools}}
 
 if [[ "${GNOME_VERSION:-49}" == "50" ]]; then
-    dnf -y install gnome50-el10-compat
+    dnf -y install gnome50-el10-compat lgda
 else
-    dnf -y install gnome49-el10-compat
+    dnf -y install gnome49-el10-compat lgda
 fi
 
 # This package adds "[systemd] Failed Units: *" to the bashrc startup


### PR DESCRIPTION
## Summary

- Installs `lgda` alongside `gnome49-el10-compat` / `gnome50-el10-compat` in `10-packages-image-base.sh`
- Package is now available in both `jreilly1821/c10s-gnome-49` and `jreilly1821/c10s-gnome-50-fresh` COPRs, which are already enabled at this point in the build

## Test plan

- [ ] Verify build succeeds for GNOME 49 variant
- [ ] Verify build succeeds for GNOME 50 variant
- [ ] Confirm `lgda` is present and functional on the built image

🤖 Generated with [Claude Code](https://claude.com/claude-code)