### PR TITLE
chore(hwe): bump kernel pin to 6.19.12-100.fc42

### DIFF
--- a/.github/workflows/build-dx-hwe.yml
+++ b/.github/workflows/build-dx-hwe.yml
@@ -33,7 +33,7 @@ jobs:
     with:
       image-name: bluefin-dx
       flavor: dx
-      kernel-pin: 6.17.12-200.fc42
+      kernel-pin: 6.19.12-100.fc42
       rechunk: ${{ github.event_name != 'pull_request' }}
       publish: ${{ (github.event_name == 'workflow_dispatch' && (github.ref == 'refs/heads/lts' || github.ref == 'refs/heads/main')) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
       hwe: true

--- a/.github/workflows/build-regular-hwe.yml
+++ b/.github/workflows/build-regular-hwe.yml
@@ -32,7 +32,7 @@ jobs:
       attestations: write
     with:
       image-name: bluefin
-      kernel-pin: 6.17.12-200.fc42
+      kernel-pin: 6.19.12-100.fc42
       rechunk: ${{ github.event_name != 'pull_request' }}
       publish: ${{ (github.event_name == 'workflow_dispatch' && (github.ref == 'refs/heads/lts' || github.ref == 'refs/heads/main')) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
       hwe: true


### PR DESCRIPTION
## Summary

Bumps the HWE kernel pin from `6.17.12-200.fc42` to `6.19.12-100.fc42` in both HWE build workflows.

`6.19.14` is available in Fedora but was skipped — no matching `akmods-zfs:coreos-stable-42-6.19.14` image exists yet in `ghcr.io/ublue-os/akmods-zfs`. Latest available is `6.19.12-100.fc42`.

## Changed files
- `.github/workflows/build-regular-hwe.yml`
- `.github/workflows/build-dx-hwe.yml`