### PR TITLE
fix(ci): replace broken reusable workflow call with inline just check + lint

### DIFF
--- a/.github/workflows/pr-testsuite.yml
+++ b/.github/workflows/pr-testsuite.yml
@@ -12,5 +12,23 @@ concurrency:
 
 jobs:
   validate:
-    uses: projectbluefin/testsuite/.github/workflows/pr-validate.yml@main
-    secrets: inherit
+    name: Lint & syntax
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Install just
+        uses: taiki-e/install-action@just
+
+      - name: Install shellcheck
+        run: sudo apt-get install -y shellcheck
+
+      - name: Check justfile syntax
+        run: just check
+
+      - name: Shellcheck
+        run: just lint


### PR DESCRIPTION
## Problem

`pr-validate.yml` in `projectbluefin/testsuite` does not have a `workflow_call` trigger — it is a standalone linter for the testsuite repo itself. Every PR was failing with `X This run likely failed because of a workflow file issue`.

## Fix

Replace the broken `uses:` call with inline steps that run the repo's own validation:
- `just check` — justfile syntax
- `just lint` — shellcheck on all .sh files

Both pass locally. SC1091 from shellcheck is an `info` (exit 0), not an error.