### PR TITLE
feat(ci): auto-merge Renovate PRs after pr-testsuite passes

### DIFF
--- a/.github/workflows/renovate-automerge.yml
+++ b/.github/workflows/renovate-automerge.yml
@@ -1,0 +1,48 @@
+name: Renovate Auto-merge
+
+on:
+  workflow_run:
+    workflows: ["PR Validation — testsuite"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    name: Auto-merge Renovate PRs
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Find Renovate PR for this commit
+        id: find-pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          PR_NUMBER=$(gh pr list \
+            --repo ${{ github.repository }} \
+            --state open \
+            --json number,headRefOid,author \
+            --jq ".[] | select(.headRefOid == \"$HEAD_SHA\") | select(.author.login == \"renovate[bot]\") | .number" \
+            | head -1)
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No open Renovate PR found for SHA $HEAD_SHA — skipping"
+            echo "pr_number=" >> "$GITHUB_OUTPUT"
+          else
+            echo "Found Renovate PR #$PR_NUMBER"
+            echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Enable auto-merge
+        if: steps.find-pr.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr merge ${{ steps.find-pr.outputs.pr_number }} \
+            --auto \
+            --merge \
+            --repo ${{ github.repository }}
+          echo "✅ Auto-merge enabled on PR #${{ steps.find-pr.outputs.pr_number }}"

--- a/.github/workflows/scheduled-lts-release.yml
+++ b/.github/workflows/scheduled-lts-release.yml
@@ -144,21 +144,6 @@ jobs:
           gh run watch "$RUN_ID" --exit-status --repo ${{ github.repository }}
           echo "✅ GDX LTS build completed successfully"
 
-      - name: Trigger release generation
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-
-          # Build is confirmed complete — the new lts-YYYYMMDD tag is in GHCR.
-          # generate-release.yml queries GHCR for the latest tag, so it will
-          # now find the tag from this week's build instead of the previous one.
-          gh workflow run generate-release.yml --ref main -f target=lts \
-            -R ${{ github.repository }}
-
-          echo "✅ Triggered release generation"
-          echo "View workflow runs at: ${{ github.server_url }}/${{ github.repository }}/actions"
-
   testsuite:
     name: Testsuite — post-release smoke
     needs: trigger-lts-builds
@@ -166,3 +151,21 @@ jobs:
     with:
       image: ghcr.io/ublue-os/bluefin:lts
       suites: smoke
+
+  generate-release:
+    name: Generate release
+    needs: testsuite
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Trigger release generation
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh workflow run generate-release.yml --ref main -f target=lts \
+            -R ${{ github.repository }}
+          echo "✅ Triggered release generation (e2e smoke passed)"
+          echo "View workflow runs at: ${{ github.server_url }}/${{ github.repository }}/actions"


### PR DESCRIPTION
## Summary
- add a workflow that enables GitHub auto-merge for Renovate PRs after PR Validation — testsuite succeeds
- detect the matching open Renovate PR by workflow_run head SHA
- invoke gh pr merge --auto --merge to enqueue merge queue auto-merge

## Validation
- just check
- yamllint -d relaxed .github/workflows/renovate-automerge.yml