### PR TITLE
fix(renovate): schedule projectbluefin/testsuite updates weekly

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,6 +32,12 @@
 
   "packageRules": [
     {
+      // testsuite tracks main by digest with no tags; updates are merged weekly to prevent commit-level spam
+      "matchDepNames": ["projectbluefin/testsuite"],
+      "schedule": ["before 9am on Monday"],
+      "automerge": true
+    },
+    {
       // Auto-merge all digest/pin updates across all managers (dockerfile, github-actions, regex/Justfile)
       "automerge": true,
       "matchUpdateTypes": ["digest", "pin", "pinDigest"]


### PR DESCRIPTION
## Problem

Enabling the e2e gate in `scheduled-lts-release.yml` added a reference to `projectbluefin/testsuite` tracked by digest against `main`. Since that repo has no version tags and receives commits many times per day, Renovate was creating and auto-merging 5+ digest-bump PRs every day (PRs #1418–#1437 in ~48 hours).

## Fix

Add a `packageRule` in `.github/renovate.json5` that restricts `projectbluefin/testsuite` digest updates to **Monday mornings only**. All digest changes from the week accumulate and land as a single PR instead of per-commit noise.

The e2e gate itself is preserved — it's a valid quality gate. Only the update cadence changes.

## After this PR

- One `projectbluefin/testsuite` digest PR per week (Monday) instead of per commit
- Auto-merge still applies, so no manual action needed

Closes the spam started by the e2e gate added in 734df7525.