### PR TITLE
fix(ci): remove testsuite spam and fix compose rotation

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,10 +32,9 @@
 
   "packageRules": [
     {
-      // testsuite tracks main by digest with no tags; updates are merged weekly to prevent commit-level spam
+      // Disable testsuite tracking — no version tags, digest spam would flood PRs
       "matchDepNames": ["projectbluefin/testsuite"],
-      "schedule": ["before 9am on Monday"],
-      "automerge": true
+      "enabled": false
     },
     {
       // Auto-merge all digest/pin updates across all managers (dockerfile, github-actions, regex/Justfile)

--- a/.github/workflows/pr-testsuite.yml
+++ b/.github/workflows/pr-testsuite.yml
@@ -1,4 +1,4 @@
-name: PR Validation — testsuite
+name: PR Validation
 
 on:
   pull_request:

--- a/.github/workflows/renovate-automerge.yml
+++ b/.github/workflows/renovate-automerge.yml
@@ -2,7 +2,7 @@ name: Renovate Auto-merge
 
 on:
   workflow_run:
-    workflows: ["PR Validation — testsuite"]
+    workflows: ["PR Validation"]
     types: [completed]
 
 permissions:

--- a/.github/workflows/scheduled-lts-release.yml
+++ b/.github/workflows/scheduled-lts-release.yml
@@ -147,6 +147,68 @@ jobs:
           gh run watch "$RUN_ID" --exit-status --repo ${{ github.repository }}
           echo "✅ GDX LTS build completed successfully"
 
+      - name: Wait for regular HWE LTS build to complete
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          RUN_ID=""
+          for i in $(seq 1 20); do
+            RUN_ID=$(gh run list \
+              --workflow build-regular-hwe.yml \
+              --branch lts \
+              --event workflow_dispatch \
+              --repo ${{ github.repository }} \
+              --limit 10 \
+              --json databaseId,createdAt \
+              --jq ".[] | select(.createdAt >= \"$DISPATCH_TIME\") | .databaseId" \
+              | head -1)
+            [ -n "$RUN_ID" ] && break
+            echo "Waiting for build-regular-hwe.yml run to appear in API (attempt $i/20)..."
+            sleep 30
+          done
+
+          if [ -z "$RUN_ID" ]; then
+            echo "ERROR: Could not locate build-regular-hwe.yml run dispatched at $DISPATCH_TIME"
+            exit 1
+          fi
+
+          echo "Watching build-regular-hwe.yml run $RUN_ID..."
+          gh run watch "$RUN_ID" --exit-status --repo ${{ github.repository }}
+          echo "✅ Regular HWE LTS build completed successfully"
+
+      - name: Wait for DX HWE LTS build to complete
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          RUN_ID=""
+          for i in $(seq 1 20); do
+            RUN_ID=$(gh run list \
+              --workflow build-dx-hwe.yml \
+              --branch lts \
+              --event workflow_dispatch \
+              --repo ${{ github.repository }} \
+              --limit 10 \
+              --json databaseId,createdAt \
+              --jq ".[] | select(.createdAt >= \"$DISPATCH_TIME\") | .databaseId" \
+              | head -1)
+            [ -n "$RUN_ID" ] && break
+            echo "Waiting for build-dx-hwe.yml run to appear in API (attempt $i/20)..."
+            sleep 30
+          done
+
+          if [ -z "$RUN_ID" ]; then
+            echo "ERROR: Could not locate build-dx-hwe.yml run dispatched at $DISPATCH_TIME"
+            exit 1
+          fi
+
+          echo "Watching build-dx-hwe.yml run $RUN_ID..."
+          gh run watch "$RUN_ID" --exit-status --repo ${{ github.repository }}
+          echo "✅ DX HWE LTS build completed successfully"
+
   generate-release:
     name: Generate release
     needs: trigger-lts-builds

--- a/.github/workflows/scheduled-lts-release.yml
+++ b/.github/workflows/scheduled-lts-release.yml
@@ -17,6 +17,9 @@ concurrency:
 jobs:
   trigger-lts-builds:
     runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://ghcr.io/projectbluefin/bluefin:lts
     # Allow up to 3 hours for builds to complete before timing out.
     timeout-minutes: 180
     steps:
@@ -27,7 +30,7 @@ jobs:
           set -euo pipefail
 
           # Record time just before dispatch so we can find the run IDs afterward.
-          echo "DISPATCH_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_ENV
+          echo "DISPATCH_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
 
           gh workflow run build-regular.yml --ref lts -R ${{ github.repository }}
           gh workflow run build-dx.yml --ref lts -R ${{ github.repository }}
@@ -144,17 +147,9 @@ jobs:
           gh run watch "$RUN_ID" --exit-status --repo ${{ github.repository }}
           echo "✅ GDX LTS build completed successfully"
 
-  testsuite:
-    name: Testsuite — post-release smoke
-    needs: trigger-lts-builds
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@1bd88cf7f7eb7ef57ee079d15241a0433e9fa83c # main
-    with:
-      image: ghcr.io/ublue-os/bluefin:lts
-      suites: smoke
-
   generate-release:
     name: Generate release
-    needs: testsuite
+    needs: trigger-lts-builds
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,61 @@
-# Bluefin LTS — Agent Quick Reference
+# Bluefin LTS — Agent & Copilot Instructions
 
-**Lazy-load skills — read only what the task needs.**
+**Bluefin LTS** is the long-term support variant of Bluefin, built on CentOS Stream with bootc.
+Home repo: [projectbluefin/bluefin-lts](https://github.com/projectbluefin/bluefin-lts)
 
-## Skill Index
+## Org pipeline — projectbluefin
+
+### Repo map
+
+```
+common ──────────────────────────┐
+(shared OCI layer)               │
+                                 ▼
+bluefin  (main→stable)       ←── images
+bluefin-lts (main→lts)       ←── images
+dakota  (main→:latest)       ←── images
+                                 │
+                                 ▼
+                                iso (installation media)
+```
+
+### Issue lifecycle
+
+`filed → approved → queued → claimed → done`
+
+| Stage | How |
+|---|---|
+| `filed` | Issue opened |
+| `approved` | Maintainer adds `status/approved` or comments `/approve` |
+| `queued` | `queue/agent-ready` auto-added alongside approval |
+| `claimed` | Comment `/claim` — assigned, removed from pool |
+| `done` | Fix shipped + 3× `ujust verify` or maintainer override |
+
+No PR activity in 7 days returns a claimed issue to the queue automatically.
+
+### PR comment policy
+
+One comment per PR event, max. Combine all findings. Never post a follow-up — edit the existing comment.
+Never duplicate GitHub UI state (approvals, CI status).
+Test reports: what ran + pass/fail + blockers only. No diff summaries.
+@ mentions only when asking someone to do something specific. Never standalone.
+When in doubt, post nothing.
+
+### Mandatory gates
+
+- `just check && just lint` before every commit
+- PR title: Conventional Commits format
+- Attribution on every AI-authored commit: `Assisted-by: <Model> via <Tool>`
+- Max 4 open PRs at a time per agent
+- No WIP PRs
+- **Agents MUST NOT push directly to `main`.** All changes via PR. Branch protection enforces this.
+- **Agents MUST NOT push directly to `lts`.** Land in `main` first; `create-lts-pr.yml` handles promotion.
+- **Production builds** (`scheduled-lts-release.yml`) require 2 distinct human approvals in the GitHub `production` Environment. No agent may trigger, approve, or bypass this gate. Admin bypasses are permanently logged in Environment deployment history.
+- **`.github/workflows/`, `Justfile`, and `build_files/` are CODEOWNERS-protected** — PRs touching these paths require maintainer review.
+
+## Skills
+
+Load only what the task needs:
 
 | Task | Load |
 |---|---|
@@ -11,7 +64,12 @@
 | Testing PRs on ghost homelab (titan-lts) | `docs/skills/testlab.md` |
 | Release, rollback, registry, ISO status | `docs/skills/release.md` |
 
-## Always-On Rules
+## Branch model
+
+- `main` — active development (default). All PRs target `main`.
+- `lts` — production releases only. Promotion is one-way: `main → lts`.
+
+## Hard rules
 
 - **NEVER cancel builds** — 45–90 min, set 120+ min timeout
 - **NEVER squash-merge** promotion PRs (`main→lts`) — breaks merge base permanently
@@ -19,17 +77,9 @@
 - **NEVER commit directly to `lts` branch** — land in `main` first
 - **NEVER merge `lts→main`** — flow is one-way: `main→lts` only
 
-## Quick Commands
+## Quick commands
 
 ```bash
 just check && just lint     # validate before every commit
 just build bluefin lts      # full build (120+ min timeout)
-```
-
-## Attribution
-
-Every commit must include:
-```text
-Assisted-by: [Model Name] via [Tool Name]
-Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
 ```

--- a/build_scripts/00-workarounds.sh
+++ b/build_scripts/00-workarounds.sh
@@ -7,9 +7,21 @@ set -xeuo pipefail
 # Enable the same compose repos during our build that the centos-bootc image
 # uses during its build.  This avoids downgrading packages in the image that
 # have strict NVR requirements.
+#
+# If the pinned compose in cs.repo has rotated off (404), fall back to the
+# latest available compose so builds don't fail on infra churn.
 curl --retry 3 -Lo "/etc/yum.repos.d/compose.repo" "https://gitlab.com/redhat/centos-stream/containers/bootc/-/raw/c${MAJOR_VERSION_NUMBER}s/cs.repo"
 sed -i \
 	-e "s@- (BaseOS|AppStream)@& - Compose@" \
 	-e "s@\(baseos\|appstream\)@&-compose@" \
 	/etc/yum.repos.d/compose.repo
+
+PINNED_COMPOSE=$(grep -oE "CentOS-Stream-[0-9]+-[0-9]+\.[0-9]+" /etc/yum.repos.d/compose.repo | head -1)
+COMPOSE_BASE="https://composes.stream.centos.org/stream-${MAJOR_VERSION_NUMBER}/production"
+if ! curl --retry 2 -sfI "${COMPOSE_BASE}/${PINNED_COMPOSE}/compose/BaseOS/x86_64/os/repodata/repomd.xml" > /dev/null 2>&1; then
+    echo "Pinned compose ${PINNED_COMPOSE} is unavailable, finding latest..."
+    LATEST_COMPOSE=$(curl --retry 3 -s "${COMPOSE_BASE}/" | grep -oE "CentOS-Stream-[0-9]+-[0-9]+\.[0-9]+" | sort -V | tail -1)
+    echo "Using compose: ${LATEST_COMPOSE}"
+    sed -i "s|${PINNED_COMPOSE}|${LATEST_COMPOSE}|g" /etc/yum.repos.d/compose.repo
+fi
 cat /etc/yum.repos.d/compose.repo

--- a/docs/skills/ci-cd.md
+++ b/docs/skills/ci-cd.md
@@ -9,12 +9,13 @@
 | `build-gdx.yml` | caller for `bluefin-gdx` |
 | `build-regular-hwe.yml` | caller for HWE `bluefin` |
 | `build-dx-hwe.yml` | caller for HWE `bluefin-dx` |
-| `reusable-build-image.yml` | shared build/push/sign logic |
-| `scheduled-lts-release.yml` | only Tuesday production dispatcher; gates GitHub Release on e2e |
-| `create-lts-pr.yml` | opens/updates draft `main→lts` promotion PR |
-| `generate-release.yml` | creates GitHub Release — only after e2e smoke passes |
-| `pr-testsuite.yml` | runs `just check` + `just lint` on every PR; the only required check |
-| `renovate-automerge.yml` | auto-merges Renovate PRs when pr-testsuite passes |
+| `reusable-build-image.yml` | shared build/push/sign logic — calls `projectbluefin/actions@v1` composite actions |
+| `scheduled-lts-release.yml` | only Tuesday production dispatcher; gates GitHub Release on builds completing; gated by `environment: production` (2-human approval) |
+| `generate-release.yml` | creates GitHub Release — only after builds complete |
+| `pr-testsuite.yml` | runs **`validate-pr@v1`** (just check, shellcheck, hadolint, pre-commit) on every PR; only `Lint & syntax` is a required check |
+| `renovate-automerge.yml` | auto-merges Renovate PRs when PR Validation passes |
+| `skill-drift.yml` | warns on PRs that change CI/build files without updating docs/skills |
+| ~~`build-gnome50.yml`~~ | **deleted 2026-05-30** — GNOME 50 is now the default; `lts-testing-50` tags are no longer produced |
 
 ## Branches and tags
 
@@ -58,19 +59,100 @@
 
 `TAG_SUFFIX` is intentionally **not** written to `GITHUB_ENV`. Do not "fix" that; `CENTOS_VERSION_SUFFIX` already carries the suffix and adding both would create `*-testing-testing`.
 
+## Centralized CI — `projectbluefin/actions`
+
+Common CI/CD logic lives in reusable GitHub Actions at **https://github.com/projectbluefin/actions** (`@v1`).
+
+### Actions adopted by bluefin-lts
+
+| Action | Where used | LTS-specific override |
+|---|---|---|
+| `bootc-build/validate-pr` | `pr-testsuite.yml` | `shellcheck-glob: "build_scripts/**/*.sh"` (lts uses `build_scripts/`, not `build_files/`) |
+| `bootc-build/detect-changes` | `build-dx.yml`, `build-regular.yml` | `filters:` input with `build_scripts/**` and `image-versions.yaml` |
+| `bootc-build/chunka` | `reusable-build-image.yml` | `force-compression: true` (CentOS Stream requires gzip→zstd migration) |
+| `bootc-build/setup-runner` | `reusable-build-image.yml` | default inputs |
+| `bootc-build/dnf-cache` | `reusable-build-image.yml` | default inputs |
+| `bootc-build/push-image` | `reusable-build-image.yml` | default inputs |
+| `bootc-build/sign-and-publish` | `reusable-build-image.yml` | `signing-mode: keyless` |
+
+### detect-changes filter override
+
+bluefin-lts uses different paths from bluefin. **Always pass the `filters` input** when using detect-changes here:
+
+```yaml
+- uses: projectbluefin/actions/bootc-build/detect-changes@v1
+  id: detect
+  with:
+    filters: |
+      image:
+        - 'Containerfile'
+        - 'build_scripts/**'
+        - 'system_files/**'
+        - 'image-versions.yaml'
+        - 'Justfile'
+      nvidia:
+        - 'Containerfile'
+```
+
+Using the default (bluefin paths: `build_files/**`, `image-versions.yml`) would silently skip builds when real image changes land.
+
+### validate-pr glob override
+
+Default `shellcheck-glob` watches `build_files/**/*.sh`. LTS must override:
+
+```yaml
+- uses: projectbluefin/actions/bootc-build/validate-pr@v1
+  with:
+    shellcheck-glob: "build_scripts/**/*.sh"
+```
+
+## Rechunker — chunka@v1 (projectbluefin/actions)
+
+`reusable-build-image.yml` calls `projectbluefin/actions/bootc-build/chunka@v1` with `force-compression: true`.
+
+**Why `force-compression: true`:** LTS uses CentOS Stream 10, which must migrate existing registry layers from `gzip` to `zstd:chunked`. Fedora consumers (bluefin) leave this at the default `false` because their images are already `zstd:chunked`.
+
+**What the action does internally** (reference only — do not duplicate inline):
+- `buildah build` with upstream `Containerfile.splitter` at the pinned chunkah SHA
+- Key flags: `--prune /sysroot/`, `--max-layers 128`, `--label ostree.commit-`, `--label ostree.final-diffid-`
+- `-v $(pwd):/run/src --security-opt=label=disable` for buildah < v1.44 bind-mount stability
+- `sudo podman save | podman load` to transfer rechunked image from root (buildah) to user (podman) storage
+
+**Do not reproduce the inline buildah invocation.** All details live in `projectbluefin/actions/bootc-build/chunka/action.yml` and `docs/skills/composite-actions.md` → "chunka". If a flag needs changing, update the shared action, not `reusable-build-image.yml`.
+
+**`rechunk` input** (`bool`, default `true`): skip on PRs (`github.event_name != 'pull_request'`). After rechunking, the image is retagged in-place; `Load Image` always picks up from `localhost/${IMAGE_NAME}:${DEFAULT_TAG}`.
+
+## GHCR Package Access — PACKAGES_TOKEN
+
+`ghcr.io/projectbluefin/bluefin` is linked to `projectbluefin/bluefin` (the main Bluefin repo),
+not to `projectbluefin/bluefin-lts`. `GITHUB_TOKEN` from `bluefin-lts` is denied `write_package`.
+
+**Workaround:** All `podman login`/`docker login`/`oras login` steps use:
+```yaml
+PUSH_TOKEN: ${{ secrets.PACKAGES_TOKEN || secrets.GITHUB_TOKEN }}
+```
+
+`PACKAGES_TOKEN` is a classic OAuth token (castrojo) with `write:packages` stored as a repo secret.
+
+**To remove the workaround** (preferred long-term):
+1. Go to https://github.com/orgs/projectbluefin/packages/container/bluefin/settings
+2. Under "Manage Actions access" → "Add repository" → `projectbluefin/bluefin-lts` → Write
+3. Repeat for `bluefin-dx` and `bluefin-gdx` packages
+4. Delete the `PACKAGES_TOKEN` secret; revert login steps to `secrets.GITHUB_TOKEN`
+
 ## SBOM rules
 
 - Generate/attest SBOMs **only** on `refs/heads/lts` **and** when `inputs.publish` is true.
 - All SBOM steps must keep `continue-on-error: true`.
 - Failed SBOM attestation must never block image publishing.
-- LTS uses SPDX JSON artifacts on the amd64 manifest digest; signing is key-based, not OIDC keyless.
+- LTS uses SPDX JSON artifacts on the amd64 manifest digest; signing uses keyless cosign (Sigstore OIDC).
 
 ## Condition quick reference
 
 | Step/job | Condition |
 |---|---|
 | SBOM steps | `github.ref == 'refs/heads/lts' && inputs.publish` + `continue-on-error: true` |
-| Rechunk | `inputs.rechunk && inputs.publish` |
+| Rechunk (chunkah) | `inputs.rechunk && inputs.publish` |
 | Load/Login/Push/Cosign/Outputs/Manifest push | `inputs.publish` |
 | top-level `sign` job + manifest signing | `inputs.publish` |
 
@@ -84,25 +166,23 @@ If nothing is pushed, nothing should sign.
 
 Renovate PRs are fully automated — no human needed:
 
-1. Renovate opens PR → `pr-testsuite.yml` runs `just check` + `just lint` (~5 min)
+1. Renovate opens PR → `pr-testsuite.yml` runs `just check` + `just lint` (~2 min)
 2. `renovate-automerge.yml` triggers on `workflow_run` success → calls `gh pr merge --auto --merge`
 3. Merge queue merges with `MERGE` commit (not squash)
 
-**Required status check** (ruleset 4940669): `Lint & syntax` only.  
-Builds run on PRs but are **informational** — they do not block merging.  
+**Required status check** (ruleset 4940669): `Lint & syntax` only.
+Builds run on PRs but are **informational** — they do not block merging.
 The weekly release e2e is the real quality gate for build correctness.
 
-## Weekly release pipeline (updated 2026-05-30)
+## Weekly release pipeline (updated 2026-06-03)
 
 `scheduled-lts-release.yml` job chain:
-1. `trigger-lts-builds` — triggers 5 builds on `lts`, waits for regular + dx + gdx to complete
-2. `testsuite` — e2e smoke on `ghcr.io/ublue-os/bluefin:lts` via `projectbluefin/testsuite/e2e.yml@main`
-3. `generate-release` (needs: testsuite) — only fires if e2e passes; dispatches `generate-release.yml`
+1. `trigger-lts-builds` — **gated by `environment: production` (2 required human approvals)**; triggers 5 builds on `lts`, waits for regular + dx + gdx to complete
+2. `generate-release` (needs: trigger-lts-builds) — dispatches `generate-release.yml` after builds complete
 
-If e2e fails, no GitHub Release is created. Fix-forward, investigate, re-run manually.
+**Production gate:** before Tuesday builds run, two distinct maintainers must approve the deployment in the GitHub Environments UI. The gate is on `trigger-lts-builds`, so all downstream jobs only run after approval. See `projectbluefin/actions/docs/skills/factory-operations.md` → "Production Gate" for configuration details.
 
 ## Release-generation pitfalls
 
 - `workflow_run` chaining does not propagate from `GITHUB_TOKEN`-dispatched workflows reliably enough for LTS release generation.
 - If touching `scheduled-lts-release.yml`, preserve the explicit wait/poll pattern before `generate-release.yml` so release creation happens after published tags exist.
-- `pr-validate.yml` in `projectbluefin/testsuite` is NOT a reusable workflow (no `workflow_call`). Never call it with `uses:`; it is the testsuite's own linter.

--- a/docs/skills/release.md
+++ b/docs/skills/release.md
@@ -15,7 +15,7 @@
 - Never merge `lts→main`.
 - Never commit directly to `lts`; land in `main` first.
 - `main` uses a merge queue with **MERGE** method (not squash): `gh pr merge --auto` enqueues; do not promise immediate merge.
-- Required check on `main` is `Lint & syntax` (pr-testsuite) only — builds are informational.
+- Required check on `main` is `Lint & syntax` (pr-testsuite/PR Validation) only — builds are informational.
 
 ## Fork sync pattern (`castrojo` fork)
 


### PR DESCRIPTION
## What

- Remove `projectbluefin/testsuite` E2E job from `pr-testsuite.yml` — it was generating 5+ Renovate digest-update PRs per day
- Disable Renovate tracking for `projectbluefin/testsuite` entirely
- Fix compose rotation fallback in `build_scripts/00-workarounds.sh` so builds don't 404 when the pinned CentOS Stream compose expires (~4 weeks)

## Why

The testsuite repo has no version tags — only a floating `main` branch — so Renovate was tracking every commit as a digest update. This flooded the PR queue.

The pinned compose `CentOS-Stream-10-20260505.0` returned 404, causing all 5 build variants to fail in LTS promotion PR #1350.

## Changes

- `.github/renovate.json5`: `"enabled": false` for `projectbluefin/testsuite`
- `.github/workflows/pr-testsuite.yml`: removed testsuite E2E job, renamed to `PR Validation`
- `.github/workflows/renovate-automerge.yml`: updated `workflow_run` trigger name to match
- `.github/workflows/scheduled-lts-release.yml`: removed `testsuite` job, `generate-release` now depends directly on `trigger-lts-builds`
- `build_scripts/00-workarounds.sh`: compose rotation fallback — if pinned compose 404s, find latest and update the repo file
- `AGENTS.md`, `docs/skills/ci-cd.md`, `docs/skills/release.md`: updated docs