### PR TITLE
chore: stub generate-release pending SBOM artifact upload (fixes projectbluefin/bluefin-lts#74)

### DIFF
--- a/.github/workflows/generate-release.yml
+++ b/.github/workflows/generate-release.yml
@@ -1,5 +1,11 @@
 name: Generate Release
 
+# TODO(bluefin-lts#74): migrate to bootc-build/create-release once the build
+# workflow uploads the SBOM as a GitHub Actions artifact.
+# https://github.com/projectbluefin/bluefin-lts/issues/74
+#
+# Stub — current behaviour preserved. Replace with create-release after #74.
+
 permissions:
   contents: write
 


### PR DESCRIPTION
## Summary

Stubs the `generate-release.yml` workflow with a TODO pointing to [projectbluefin/bluefin-lts#74](https://github.com/projectbluefin/bluefin-lts/issues/74). **Behaviour is unchanged** — no-op PR that adds the tracking comment.

The full migration to `bootc-build/create-release` is blocked on the build workflow uploading the SBOM as a GitHub Actions artifact. See #74 for what needs to change.

## Tracking

- Actions PR: https://github.com/projectbluefin/actions/pull/109
- Blocking issue: https://github.com/projectbluefin/bluefin-lts/issues/74

## Out-of-org consumer impact

N/A