### PR TITLE
fix(packages): specify fedora-44 chroot for ublue-os/packages COPR

### DIFF
--- a/build_scripts/20-packages.sh
+++ b/build_scripts/20-packages.sh
@@ -52,8 +52,8 @@ dnf config-manager --set-disabled "tailscale-stable"
 dnf -y --enablerepo "tailscale-stable" install \
 	tailscale
 
-dnf -y copr enable ublue-os/packages 
-dnf -y copr disable ublue-os/packages 
+dnf -y copr enable ublue-os/packages "fedora-44-$(arch)"
+dnf -y copr disable ublue-os/packages
 dnf -y --enablerepo copr:copr.fedorainfracloud.org:ublue-os:packages install uupd
 
 dnf -y copr enable che/nerd-fonts "centos-stream-${MAJOR_VERSION_NUMBER}-$(arch)"


### PR DESCRIPTION
## What

Specifies `fedora-44-$(arch)` as the explicit chroot when enabling the `ublue-os/packages` COPR.

## Why

The `ublue-os/packages` COPR project's latest build (#10605423) dropped `epel-10` / `centos-stream-10` chroots. Without an explicit chroot, `dnf copr enable` on CentOS Stream 10 auto-detects `centos-stream-10`, finds no match, and fails:

```
Error: It wasn't possible to enable this project.
Available repositories: 'fedora-41-aarch64', 'fedora-43-x86_64', 'fedora-43-aarch64', 'fedora-44-x86_64', 'fedora-44-aarch64', ...
```

This has been breaking all main branch builds since ~2026-06-15.

The `uupd` Go binary from the Fedora 44 chroot is compatible with CentOS Stream 10.

## Testing

Replaces the failing builds triggered by commits since 2026-06-15 (runs 27577816353, 27588788521, 27640442378).