### PR TITLE
fix(ci): increase build timeout to 120 min, fix testsuite registry path

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -103,7 +103,7 @@ jobs:
   build_push:
     name: Build and push image
     runs-on: ${{ matrix.platform == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
-    timeout-minutes: 60
+    timeout-minutes: 120
     needs: generate_matrix
     strategy:
       fail-fast: false

--- a/.github/workflows/scheduled-lts-release.yml
+++ b/.github/workflows/scheduled-lts-release.yml
@@ -149,7 +149,7 @@ jobs:
     needs: trigger-lts-builds
     uses: projectbluefin/testsuite/.github/workflows/e2e.yml@1bd88cf7f7eb7ef57ee079d15241a0433e9fa83c # main
     with:
-      image: ghcr.io/ublue-os/bluefin:lts
+      image: ghcr.io/${{ github.repository_owner }}/bluefin:lts
       suites: smoke
 
   generate-release:


### PR DESCRIPTION
## What

Two targeted CI fixes to unblock building and stable release:

1. **`reusable-build-image.yml`** — `timeout-minutes: 60` → `120`  
   Builds run 45–90 min. The 60-min cap was cancelling them, violating the "never cancel builds" rule.

2. **`scheduled-lts-release.yml`** — replace hardcoded `ghcr.io/ublue-os/bluefin:lts` with `ghcr.io/${{ github.repository_owner }}/bluefin:lts` in the testsuite job  
   Smoke test was pulling from the wrong org if the repo ever moves.

## Validation

- `actionlint` clean on changed files (pre-existing warnings in unrelated files)
- No new files, no scope creep