### PR TITLE
fix(ci): disable arm64 builds, amd64 only

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -21,7 +21,7 @@ on:
         description: "The platforms to build the image for"
         required: false
         type: string
-        default: "amd64,arm64"
+        default: "amd64"
       centos-version:
         description: "The version of CentOS to build the image on"
         required: false


### PR DESCRIPTION
arm64 builds blocked on `gjs` missing `epel-10-aarch64` chroot in `jreilly1821/c10s-gnome-49` COPR. Unblocking amd64 release by dropping arm64 from the default platforms until upstream COPR is fixed.