### PR TITLE
fix(gnome49): add --skip-unavailable to dnf upgrade for COPR packages

### DIFF
--- a/build_scripts/overrides/base/10-packages-image-base.sh
+++ b/build_scripts/overrides/base/10-packages-image-base.sh
@@ -29,7 +29,7 @@ if [[ "${GNOME_VERSION:-49}" == "50" ]]; then
     #   architecture; EL10 base 42.x lacks the necessary policy rules.
     # - gnutls: newer glib2 from COPR may depend on gnutls symbols not in base.
     dnf -y install selinux-policy selinux-policy-targeted gnutls
-    dnf -y upgrade glib2 fontconfig
+    dnf -y upgrade --skip-unavailable glib2 fontconfig
 else
     # GNOME 49 COPR (default)
     dnf copr enable -y "jreilly1821/c10s-gnome-49"
@@ -52,7 +52,7 @@ else
     #   double-registering GIRepository crashes gnome-shell at startup.
     # - gnutls: newer glib2 from COPR may depend on gnutls symbols not in base.
     dnf -y install selinux-policy selinux-policy-targeted gnutls
-    dnf -y upgrade glib2 fontconfig gobject-introspection gjs
+    dnf -y upgrade --skip-unavailable glib2 fontconfig gobject-introspection gjs
 fi
 
 # Please, dont remove this as it will break everything GNOME related


### PR DESCRIPTION
## What

`dnf -y upgrade fontconfig gjs` in the GNOME 49 path fails with `No match for argument` in dnf5 — hard error even when other packages in the same command succeed. This happens when base EL10 already ships the required version (nothing to upgrade from the COPR).

Fix: `--skip-unavailable` lets dnf upgrade what it finds and silently skips packages already at the right version.

Applied to both GNOME 49 and GNOME 50 upgrade lines.