### PR TITLE
fix(gnome): skip selinux-policy scriptlets in container build

### DIFF
--- a/build_scripts/overrides/base/10-packages-image-base.sh
+++ b/build_scripts/overrides/base/10-packages-image-base.sh
@@ -28,7 +28,7 @@ if [[ "${GNOME_VERSION:-49}" == "50" ]]; then
     # - selinux-policy: COPR 43.x is required for GDM 49/50 userdb varlink socket
     #   architecture; EL10 base 42.x lacks the necessary policy rules.
     # - gnutls: newer glib2 from COPR may depend on gnutls symbols not in base.
-    dnf -y install selinux-policy selinux-policy-targeted gnutls
+    dnf -y install --setopt=tsflags=noscripts selinux-policy selinux-policy-targeted gnutls
     dnf -y upgrade --skip-unavailable glib2 fontconfig
 else
     # GNOME 49 COPR (default)
@@ -51,7 +51,7 @@ else
     #   and libgirepository-2.0. If only one is upgraded, both get loaded and
     #   double-registering GIRepository crashes gnome-shell at startup.
     # - gnutls: newer glib2 from COPR may depend on gnutls symbols not in base.
-    dnf -y install selinux-policy selinux-policy-targeted gnutls
+    dnf -y install --setopt=tsflags=noscripts selinux-policy selinux-policy-targeted gnutls
     dnf -y upgrade --skip-unavailable glib2 fontconfig gobject-introspection gjs
 fi
 


### PR DESCRIPTION
`selinux-policy-targeted 43.4` (newly rebuilt in `jreilly1821/c10s-gnome-49` COPR today) has a `%posttrans` scriptlet that runs `semodule -B`, which exits 2 inside a container — there's no kernel to load the policy into.\n\n`--setopt=tsflags=noscripts` skips scriptlet execution while still installing the policy files on disk. Policy loads correctly at first boot via the host SELinux stack. Standard practice for selinux-policy in container image builds.\n\nApplied to both GNOME 49 and GNOME 50 paths.