### PR TITLE
fix(packages): use epel-10 chroot for uupd COPR, add retries

### DIFF
--- a/build_scripts/20-packages.sh
+++ b/build_scripts/20-packages.sh
@@ -52,8 +52,8 @@ dnf config-manager --set-disabled "tailscale-stable"
 dnf -y --enablerepo "tailscale-stable" install \
 	tailscale
 
-dnf -y copr enable ublue-os/packages "fedora-44-$(arch)"
-dnf -y install uupd
+dnf -y copr enable ublue-os/packages "epel-10-$(arch)"
+dnf -y --setopt=retries=5 install uupd
 dnf -y copr disable ublue-os/packages
 
 dnf -y copr enable che/nerd-fonts "centos-stream-${MAJOR_VERSION_NUMBER}-$(arch)"


### PR DESCRIPTION
uupd build 10618252 is in `epel-10-x86_64`/`epel-10-aarch64`. The old `fedora-44-$(arch)` chroot points to a different results directory that no longer has uupd packages, causing CDN failures and "No match".\n\n- `epel-10-$(arch)`: correct chroot for current uupd build\n- `--setopt=retries=5`: survive transient COPR CDN blips