### PR TITLE
fix(dx): self-contained copr enable/disable for ublue-os/packages

### DIFF
--- a/build_scripts/overrides/dx/00-packages.sh
+++ b/build_scripts/overrides/dx/00-packages.sh
@@ -17,12 +17,14 @@ dnf -y --enablerepo docker-ce-stable install \
   docker-buildx-plugin \
   docker-compose-plugin
 
-dnf -y --enablerepo copr:copr.fedorainfracloud.org:ublue-os:packages install \
+dnf -y copr enable ublue-os/packages "epel-10-$(arch)"
+dnf -y install \
   libvirt \
   libvirt-daemon-kvm \
   libvirt-nss \
   virt-install \
   ublue-os-libvirt-workarounds
+dnf -y copr disable ublue-os/packages
 
 dnf -y --setopt=install_weak_deps=False install \
   cockpit-bridge \


### PR DESCRIPTION
`dnf copr disable` rewrites the repo baseurl to the OS-native chroot (`centos-stream-10-x86_64`) which doesn't exist in the COPR. The DX script was using `--enablerepo` after `20-packages.sh` already disabled the COPR, hitting that rewritten dead URL and failing to find `ublue-os-libvirt-workarounds`.\n\nFix: inline `copr enable epel-10-$(arch)` before the libvirt install and `copr disable` after. Self-contained, no dependency on `20-packages.sh` state.