### PR TITLE
fix(ci): revert testsuite image to hardcoded ublue-os owner

### DIFF
--- a/.github/workflows/scheduled-lts-release.yml
+++ b/.github/workflows/scheduled-lts-release.yml
@@ -149,7 +149,7 @@ jobs:
     needs: trigger-lts-builds
     uses: projectbluefin/testsuite/.github/workflows/e2e.yml@1bd88cf7f7eb7ef57ee079d15241a0433e9fa83c # main
     with:
-      image: ghcr.io/${{ github.repository_owner }}/bluefin:lts
+      image: ghcr.io/ublue-os/bluefin:lts
       suites: smoke
 
   generate-release:


### PR DESCRIPTION
`${{ github.repository_owner }}` in a `uses:` job `with:` block causes `startup_failure`. This repo lives under `ublue-os`; the hardcoded value is correct and safe.