### PR TITLE
fix(gnome): pin mutter to 49.4-4.el10 to stop GNOME Shell boot crash

### DIFF
--- a/build_scripts/overrides/base/10-packages-image-base.sh
+++ b/build_scripts/overrides/base/10-packages-image-base.sh
@@ -137,6 +137,34 @@ else
     dnf -y install gnome49-el10-compat libgda
 fi
 
+# TEMPORARY: pin mutter to 49.4-4.el10 to stop the GNOME Shell boot crash.
+#
+# CentOS Stream 10's mutter-49.4-6.el10 backported a keymap patch (RHEL-106779)
+# that changed the introspected Meta.Backend.set_keymap_async API. The c10s-gnome-49
+# COPR enabled above still ships gnome-shell-49.5-100.el10gnomeqr built against the
+# old API, and its "100" release outranks CS10's lockstep rebuild, so the stale shell
+# sticks while mutter drifts to -6. gnome-shell then segfaults on login and GDM
+# crash-loops to a black screen. Known-good pair: mutter-49.4-4 + gnome-shell-49.5-100
+# (what the last working image, lts-hwe.20260519, shipped). -4 is still in the CS10
+# AppStream repo, so a plain downgrade works.
+#
+# Only affects GNOME 49; GNOME 50 uses a different COPR. gnome-shell stays at 49.5-100.
+# REMOVE THIS once c10s-gnome-49 ships a gnome-shell rebuilt against mutter >= 49.4-6
+# (tracking: tuna-os/github-copr#27, fix in tuna-os/github-copr#28).
+if [[ "${GNOME_VERSION:-49}" != "50" ]]; then
+    MUTTER_GOOD="49.4-4.el${MAJOR_VERSION_NUMBER}"
+    echo "--- pinning mutter to ${MUTTER_GOOD} (temporary GNOME Shell crash workaround) ---"
+    if [[ "$(rpm -q --qf '%{VERSION}-%{RELEASE}' mutter)" != "${MUTTER_GOOD}" ]]; then
+        dnf -y downgrade "mutter-${MUTTER_GOOD}" "mutter-common-${MUTTER_GOOD}"
+    fi
+    for n in mutter mutter-common; do
+        v="$(rpm -q --qf '%{VERSION}-%{RELEASE}' "${n}")"
+        [[ "${v}" == "${MUTTER_GOOD}" ]] || { echo "FATAL: ${n} is ${v}, expected ${MUTTER_GOOD}"; exit 1; }
+    done
+    dnf versionlock add mutter mutter-common
+    echo "mutter pinned to ${MUTTER_GOOD} and versionlocked (TEMP)"
+fi
+
 # This package adds "[systemd] Failed Units: *" to the bashrc startup
 dnf -y remove console-login-helper-messages
 


### PR DESCRIPTION
## What's broken

On the current `lts-hwe` build, GNOME Shell crashes at startup and GDM crash-loops
to a black screen. CentOS Stream 10 shipped `mutter-49.4-6.el10`, which backported a
remote-desktop keymap patch (RHEL-106779) that changed the introspected
`Meta.Backend.set_keymap_async` API. The `c10s-gnome-49` COPR still ships
`gnome-shell-49.5-100.el10gnomeqr`, built against the old API, and its `100` release
outranks CS10's lockstep rebuild. So the stale shell sticks while mutter drifts up to
`-6`, and gnome-shell segfaults at that call on login.

Last good image: `lts-hwe.20260519` (`mutter-49.4-4`). First broken: `lts-hwe.20260619`
(`mutter-49.4-6`).

## The fix

Pin `mutter` and `mutter-common` to the known-good `49.4-4.el10` in
`build_scripts/overrides/base/10-packages-image-base.sh`, then versionlock them so
nothing later in the build pulls `-6` back. `gnome-shell` stays at `49.5-100`, which is
exactly the pairing the last working image shipped. The base script runs for every
variant (lts, lts-hwe, dx, gdx), so one change covers all of them. GNOME 50 uses a
different COPR and is left alone.

It's a deliberate, fail-loud, single-block stopgap (the build aborts if mutter is not
`-4` afterward). The real fix is upstream: once the `c10s-gnome-49` COPR ships a
`gnome-shell` rebuilt against `mutter >= 49.4-6`, drop the block. Tracking and proposed
fix: tuna-os/github-copr#27 and tuna-os/github-copr#28.

## Validation

- Reproduced the break and the fix in a `centos-bootc:c10s` container: installing the
  COPR `gnome-shell` pulls `mutter-49.4-6`, and `dnf downgrade` to `-4` resolves cleanly
  with `gnome-shell-49.5-100` left in place. The versionlock holds (a later `dnf upgrade`
  does not move mutter) and `dnf check` is clean.
- `bash -n` passes and `shellcheck` adds no new warnings.
- Not done: a full image build. The depsolve that matters (gnome-shell against mutter)
  is proven above, but the dx/gdx/kernel-swap layers were not exercised locally, so a
  green CI build here closes that gap.
