### PR TITLE
fix: enable fractional scaling and fix nvidia glitches

### DIFF
--- a/build_scripts/overrides/gdx/40-overrides.sh
+++ b/build_scripts/overrides/gdx/40-overrides.sh
@@ -2,7 +2,7 @@
 
 set -xeuo pipefail
 
-sed -i "/experimental-features/ s/\]/, 'kms-modifiers'&/" /usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+sed -i "/experimental-features/ s/\]/, 'kms-modifiers'&/" /usr/share/glib-2.0/schemas/zz1-bluefin-lts-shell.gschema.override
 echo "Compiling gschema to include bluefin setting overrides"
 glib-compile-schemas /usr/share/glib-2.0/schemas
 

--- a/system_files/usr/share/glib-2.0/schemas/zz1-bluefin-lts-shell.gschema.override
+++ b/system_files/usr/share/glib-2.0/schemas/zz1-bluefin-lts-shell.gschema.override
@@ -1,0 +1,2 @@
+[org.gnome.mutter]
+experimental-features = ['scale-monitor-framebuffer', 'xwayland-native-scaling']


### PR DESCRIPTION
Fixes #1594 by adding the experimental-features key in GSchema overrides for bluefin-lts, and updating the nvidia overrides script to target this file.