### PR TITLE
feat(hwe): migrate legacy users to projectbluefin

### DIFF
--- a/build_scripts/build.sh
+++ b/build_scripts/build.sh
@@ -67,6 +67,9 @@ if [ "$ENABLE_GDX" == "1" ]; then
 	run_buildscripts_for gdx
 	copy_systemfiles_for "$(arch)-gdx"
 	run_buildscripts_for "$(arch)/gdx"
+elif [ "$ENABLE_HWE" == "1" ] && [ "$ENABLE_DX" != "1" ]; then
+	copy_systemfiles_for hwe
+	run_buildscripts_for hwe
 fi
 
 printf "::group:: ===Image Cleanup===\n"

--- a/build_scripts/overrides/hwe/40-overrides.sh
+++ b/build_scripts/overrides/hwe/40-overrides.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+# Migrate regular non-DX HWE users from the legacy ublue-os registry.
+# DX-HWE and GDX use their own migration paths and are excluded by build.sh.
+systemctl enable bluefin-lts-migration.timer

--- a/docs/skills/build.md
+++ b/docs/skills/build.md
@@ -37,7 +37,7 @@ just check && just lint
 | Regular | base LTS image |
 | DX | developer tools, VS Code, Docker |
 | GDX | GPU / AI tooling |
-| HWE | newer hardware enablement |
+| HWE | newer hardware enablement; regular non-DX HWE images include the legacy-to-Project-Bluefin migration timer |
 
 ## VM / disk artifacts
 

--- a/docs/skills/ci-cd.md
+++ b/docs/skills/ci-cd.md
@@ -108,6 +108,16 @@ GDX is triggered by `trigger-lts-builds` but the release does **not wait** for i
 - If touching `scheduled-lts-release.yml`, preserve the explicit wait/poll pattern before `generate-release.yml` so release creation happens after published tags exist.
 - **Never merge a promotion PR to `lts` while a release run is in progress.** The push to `lts` cancels all in-flight build workflows dispatched by the release, causing `trigger-lts-builds` to fail with exit code 1 when it tries to `gh run watch` the now-cancelled run. Always wait for the release to reach `generate-release` before touching `lts`.
 
+## Legacy HWE migration
+
+Regular non-DX HWE images enable `bluefin-lts-migration.timer`. The timer migrates
+legacy x86_64 images from `ghcr.io/ublue-os/bluefin-hwe:*` to
+`ghcr.io/projectbluefin/bluefin-lts:stable` via `bootc switch`.
+
+DX-HWE and GDX images are excluded from the HWE migration path. GDX retains its
+separate NVIDIA migration path. Unknown legacy image flavors fail closed; ARM64
+users receive reinstall guidance rather than an automatic switch.
+
 ## GDX build notes
 
 GDX (`build_scripts/overrides/gdx/20-nvidia.sh`) uses the **EPEL** negativo17 nvidia repo, not the Fedora one. Key facts:

--- a/system_files_overrides/hwe/usr/bin/bluefin-lts-migration
+++ b/system_files_overrides/hwe/usr/bin/bluefin-lts-migration
@@ -80,6 +80,13 @@ def main() -> int:
         )
         return 1
 
+    if "bluefin-dx" in image_ref or "-dx" in image_ref:
+        print(
+            f"WARNING: DX image ref '{image_ref}', skipping HWE migration.",
+            file=sys.stderr,
+        )
+        return 1
+
     if "bluefin-hwe" not in image_ref and "-hwe" not in image_ref:
         print(
             f"WARNING: non-HWE image ref '{image_ref}', skipping migration.",

--- a/system_files_overrides/hwe/usr/bin/bluefin-lts-migration
+++ b/system_files_overrides/hwe/usr/bin/bluefin-lts-migration
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Migrate legacy non-DX HWE images to ghcr.io/projectbluefin/."""
+
+import json
+import os
+import subprocess
+import sys
+
+MIGRATED_STAMP = "/etc/bluefin-lts-migrated"
+MOTD_DIR = "/run/motd.d"
+MOTD_FILE = f"{MOTD_DIR}/50-bluefin-lts-migration"
+TARGET_REF = "ghcr.io/projectbluefin/bluefin-lts:stable"
+TARGET_REGISTRY = "ghcr.io/projectbluefin/"
+LEGACY_REGISTRY = "ghcr.io/ublue-os/"
+
+
+def write_motd(text: str) -> None:
+    os.makedirs(MOTD_DIR, exist_ok=True)
+    with open(MOTD_FILE, "w") as f:
+        f.write(text + "\n")
+
+
+def stamp_migrated() -> None:
+    open(MIGRATED_STAMP, "w").close()
+
+
+def get_bootc_status() -> dict:
+    result = subprocess.run(
+        ["bootc", "status", "--format=json"],
+        capture_output=True, text=True, check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def current_image_ref(status: dict) -> str:
+    try:
+        return status["status"]["booted"]["image"]["image"]["image"]
+    except (KeyError, TypeError):
+        return ""
+
+
+def cleanup_legacy_systemd() -> None:
+    stale = "/etc/systemd/system/default.target.wants/nvmefc-boot-connections.service"
+    try:
+        if os.path.lexists(stale):
+            os.remove(stale)
+            print(f"Removed stale systemd unit: {stale}")
+    except OSError as exc:
+        print(f"WARNING: could not remove {stale}: {exc}", file=sys.stderr)
+
+
+def main() -> int:
+    if os.path.exists(MIGRATED_STAMP):
+        return 0
+
+    try:
+        status = get_bootc_status()
+    except (subprocess.CalledProcessError, json.JSONDecodeError, OSError) as exc:
+        print(f"ERROR: could not read bootc status: {exc}", file=sys.stderr)
+        return 1
+
+    image_ref = current_image_ref(status)
+    if TARGET_REGISTRY in image_ref:
+        stamp_migrated()
+        return 0
+
+    if os.uname().machine in ("aarch64", "arm64"):
+        write_motd(
+            "⚠️  Bluefin HWE migration: automatic migration to projectbluefin is not\n"
+            "   supported on ARM64. Please reinstall from the projectbluefin ISO.\n"
+            "   See https://projectbluefin.io for instructions."
+        )
+        stamp_migrated()
+        return 0
+
+    if not image_ref or LEGACY_REGISTRY not in image_ref:
+        print(
+            f"WARNING: unrecognized image ref '{image_ref}', skipping migration.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if "bluefin-hwe" not in image_ref and "-hwe" not in image_ref:
+        print(
+            f"WARNING: non-HWE image ref '{image_ref}', skipping migration.",
+            file=sys.stderr,
+        )
+        return 1
+
+    write_motd(
+        f"ℹ️  Bluefin HWE: your system is being migrated to {TARGET_REF}.\n"
+        "   The migration will complete on your next reboot. Please do not interrupt."
+    )
+    print(f"Switching to {TARGET_REF} …")
+    cleanup_legacy_systemd()
+
+    result = subprocess.run(
+        ["bootc", "switch", "--enforce-container-sigpolicy", TARGET_REF],
+    )
+    if result.returncode == 0:
+        stamp_migrated()
+        write_motd(
+            f"✅  Bluefin HWE migration to {TARGET_REF} complete.\n"
+            "   Please reboot to apply the update."
+        )
+        print("Migration staged successfully. Reboot to complete.")
+        return 0
+
+    print(f"ERROR: bootc switch failed (exit {result.returncode})", file=sys.stderr)
+    with open(MOTD_FILE, "a") as f:
+        f.write(
+            "\n⚠️  Migration attempt failed. It will be retried automatically.\n"
+            "   Check `journalctl -u bluefin-lts-migration.service` for details.\n"
+        )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/system_files_overrides/hwe/usr/lib/systemd/system/bluefin-lts-migration.service
+++ b/system_files_overrides/hwe/usr/lib/systemd/system/bluefin-lts-migration.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Bluefin HWE — migrate legacy image to projectbluefin registry
+Documentation=https://projectbluefin.io
+After=network-online.target
+Wants=network-online.target
+ConditionPathExists=!/etc/bluefin-lts-migrated
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+TimeoutStartSec=3600
+ExecStart=/usr/bin/bluefin-lts-migration
+
+[Install]
+WantedBy=multi-user.target

--- a/system_files_overrides/hwe/usr/lib/systemd/system/bluefin-lts-migration.timer
+++ b/system_files_overrides/hwe/usr/lib/systemd/system/bluefin-lts-migration.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Daily trigger for Bluefin HWE image migration
+Documentation=https://projectbluefin.io
+
+[Timer]
+OnCalendar=*-*-* 04:00:00
+Persistent=true
+Unit=bluefin-lts-migration.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Add a regular HWE-only migration timer and switch target. Keep DX-HWE and GDX on their existing migration paths.\n\nAssisted-by: GPT-5 via pi