### PR TITLE
fix: update ZFS userspace lib globs for OpenZFS 2.4.3 soname bump

### DIFF
--- a/build_scripts/overrides/x86_64/20-zfs.sh
+++ b/build_scripts/overrides/x86_64/20-zfs.sh
@@ -16,8 +16,8 @@ dnf -y install \
     /tmp/akmods-zfs-rpms/kmods/zfs/kmod-zfs-"${KERNEL_VRA}"-*.rpm \
     /tmp/akmods-zfs-rpms/kmods/zfs/libnvpair3-*.rpm \
     /tmp/akmods-zfs-rpms/kmods/zfs/libuutil3-*.rpm \
-    /tmp/akmods-zfs-rpms/kmods/zfs/libzfs6-*.rpm \
-    /tmp/akmods-zfs-rpms/kmods/zfs/libzpool6-*.rpm \
+    /tmp/akmods-zfs-rpms/kmods/zfs/libzfs7-*.rpm \
+    /tmp/akmods-zfs-rpms/kmods/zfs/libzpool7-*.rpm \
     /tmp/akmods-zfs-rpms/kmods/zfs/zfs-*.rpm \
     
 


### PR DESCRIPTION
## Problem

Every image build on `main` has failed since ~Aug 7 (issue #1738). The `ghcr.io/ublue-os/akmods-zfs:centos-10` cache now ships **OpenZFS 2.4.3**, which bumped the shared library sonames:

- `libzfs6` → `libzfs7`
- `libzpool6` → `libzpool7`

The install globs in `build_scripts/overrides/x86_64/20-zfs.sh` matched nothing:

```
Can not load RPM file: /tmp/akmods-zfs-rpms/kmods/zfs/libzfs6-*.rpm
Can not load RPM file: /tmp/akmods-zfs-rpms/kmods/zfs/libzpool6-*.rpm
```

## Fix

Update the two globs to `libzfs7`/`libzpool7`. Verified against the current cache image, which contains `libzfs7-2.4.3-1.el10` and `libzpool7-2.4.3-1.el10`.

## Verification

### Local build (x86_64)
- `just check && just lint` ✅
- `just build bluefin lts` ✅ — full build completes (previously died at `x86_64-20-zfs.sh`)
- In-image verification of `localhost/bluefin:lts`:
  - `zfs-2.4.3-1.el10`, `libzfs7`, `libzpool7`, `libnvpair3`, `libuutil3`, `kmod-zfs` all installed
  - `zfs.ko` + `spl.ko` present under `/lib/modules/.../extra/zfs/`
  - `zfs --version` → `zfs-2.4.3-1`

### ⚡ Vanguard Lab Strike Report: bluefin-lts-zfs-fix
**Alpha**: Blue Universal CI Companion · Iron Lord Archive · Long Watch Protocol
**Guardian on Duty**: `castrojo` on Ghost Homelab

*"The Long Watch ends when the build turns green."*

| Field | Value |
|---|---|
| Target | `bluefin-lts` |
| VM/Host | `bluefin-lts-zfs-fix` (KubeVirt, exo-0) |
| Image | `192.168.1.102:30500/bluefin-lts:zfs-soname-fix` (`aa0d65d1`) → containerDisk via local BIB QCOW2 |
| Verdict | 🟢 **GO** — image builds, boots, guest agent reports healthy Bluefin LTS |
| Trailer | `<!-- status:PASS target:lts label:zfs-soname-fix digest:aa0d65d1 --> ` |

- **Boot**: VMI Ready 51s after creation; guest agent connected; OS info: **Bluefin LTS 10 (Coughlan)**, kernel `6.12.0-260.el10.x86_64` (matches the `kmod-zfs` build target), network up
- **Note**: SSH-key injection and guest-exec are unavailable in this path (agent allowlist blocks `guest-exec`/`guest-file-*` in Bluefin's qemu-guest-agent config; KubeVirt key injection hit a `/root/.ssh exists` quirk), so deep in-guest SSH checks were not possible. ZFS content was verified directly in the built image instead.
- Also note: `build-bluefin-migration-containerdisk` template is currently broken on-cluster (buildah overlay `EINVAL` on the staging PVC, on both ghost and exo-0) — worked around by building the QCOW2 locally and wrapping it as a scratch containerDisk. Filed as a lab issue, not a repo issue.

Fixes #1738

Assisted-by: Kimi K3 via Copilot CLI