### PR TITLE
feat: replace Docker Model Runner with llmman

### DIFF
--- a/.github/changelog_config.yaml
+++ b/.github/changelog_config.yaml
@@ -73,6 +73,7 @@ templates:
     | **Docker** | {pkgrel:docker-ce} |
     | **VSCode** | {pkgrel:code} |
     | **Ramalama** | {pkgrel:ramalama} |
+    | **llmman** | {pkgrel:llmman} |
 
     ### Major GDX packages
     | Name | Version |

--- a/build_scripts/overrides/dx/00-packages.sh
+++ b/build_scripts/overrides/dx/00-packages.sh
@@ -12,7 +12,6 @@ dnf config-manager --set-disabled docker-ce-stable
 dnf -y --enablerepo docker-ce-stable install \
   docker-ce \
   docker-ce-cli \
-  docker-model-plugin \
   containerd.io \
   docker-buildx-plugin \
   docker-compose-plugin


### PR DESCRIPTION
## What does this change?

- Removes `docker-model-plugin` from the DX Docker package set in `build_scripts/overrides/dx/00-packages.sh`.
- Lists **llmman** next to **Ramalama** in the changelog's "Major DX packages" table.

## Why?

[llmman](https://github.com/llmmanorg/llmman) covers the same local model runner use case as Docker Model Runner: it pulls models from Hugging Face or any OCI registry, serves them with upstream `llama.cpp`/`vllm`, and launches coding agents against local or hosted models. It is installed via Homebrew, so the Docker plugin is no longer needed in the image.

Note: like ramalama, llmman is not an RPM in this image, so `{pkgrel:llmman}` renders `N/A` in the changelog the same way the existing Ramalama row does.

Related PRs:
- ublue-os/bluefin, ublue-os/aurora: same `docker-model-plugin` removal
- projectbluefin/common: adds llmman to `ai-tools.Brewfile`